### PR TITLE
exposing start,stop methods in exchange and subscriber

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -20,6 +20,8 @@ type Subscriber[H Header] interface {
 	// before they are sent through Subscriptions.
 	// Multiple validators can be registered.
 	AddValidator(func(context.Context, H) pubsub.ValidationResult) error
+	// Start starts the Subscriber, registering a topic validator for the "header-sub" topic and joining it.
+	Start(context.Context) error
 	// Stop removes header-sub validator and closes the topic.
 	Stop(context.Context) error
 }
@@ -43,6 +45,12 @@ type Broadcaster[H Header] interface {
 // from the network.
 type Exchange[H Header] interface {
 	Getter[H]
+
+	// Start starts the exchange.
+	Start(context.Context) error
+
+	// Stop stops the exchange
+	Stop(context.Context) error
 }
 
 var (

--- a/test/testing.go
+++ b/test/testing.go
@@ -290,5 +290,6 @@ func (mhs *DummySubscriber) NextHeader(ctx context.Context) (*DummyHeader, error
 	return mhs.Headers[0], nil
 }
 
-func (mhs *DummySubscriber) Stop(context.Context) error { return nil }
-func (mhs *DummySubscriber) Cancel()                    {}
+func (mhs *DummySubscriber) Stop(context.Context) error  { return nil }
+func (hms *DummySubscriber) Start(context.Context) error { return nil }
+func (mhs *DummySubscriber) Cancel()                     {}


### PR DESCRIPTION
while integrating the header service with rollmint, these methods needs to be exposed.