### PR TITLE
refactoring(p2p): remove timeout from handling the request range

### DIFF
--- a/p2p/options.go
+++ b/p2p/options.go
@@ -32,9 +32,9 @@ type ServerParameters struct {
 // DefaultServerParameters returns the default params to configure the store.
 func DefaultServerParameters() ServerParameters {
 	return ServerParameters{
-		WriteDeadline:       time.Second * 5,
+		WriteDeadline:       time.Second * 8,
 		ReadDeadline:        time.Minute,
-		RangeRequestTimeout: time.Second * 5,
+		RangeRequestTimeout: time.Second * 10,
 	}
 }
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -123,11 +123,13 @@ func (serv *ExchangeServer[H]) requestHandler(stream network.Stream) {
 	if code != p2p_pb.StatusCode_OK {
 		headers = make([]H, 1)
 	}
+
+	if err := stream.SetWriteDeadline(time.Now().Add(serv.Params.WriteDeadline)); err != nil {
+		log.Debugf("error setting deadline: %s", err)
+	}
+
 	// write all headers to stream
 	for _, h := range headers {
-		if err := stream.SetWriteDeadline(time.Now().Add(serv.Params.ReadDeadline)); err != nil {
-			log.Debugf("error setting deadline: %s", err)
-		}
 		var bin []byte
 		// if header is not nil, then marshal it to []byte.
 		// if header is nil, then error was received,so we will set empty []byte to proto.
@@ -186,10 +188,7 @@ func (serv *ExchangeServer[H]) handleRequest(from, to uint64) ([]H, error) {
 		return serv.handleHeadRequest()
 	}
 
-	ctx, cancel := context.WithTimeout(serv.ctx, serv.Params.RangeRequestTimeout)
-	defer cancel()
-
-	ctx, span := tracer.Start(ctx, "request-range", trace.WithAttributes(
+	ctx, span := tracer.Start(context.Background(), "request-range", trace.WithAttributes(
 		attribute.Int64("from", int64(from)),
 		attribute.Int64("to", int64(to))))
 	defer span.End()


### PR DESCRIPTION
## Overview
We do not need a timeout in handling the range request on the server side, as we have implemented an extra check that ensures that this range has height less than store.Head

## Checklist
- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
