### PR TITLE
Publish initial head via heightSub and use native atomic type

### DIFF
--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -16,7 +16,7 @@ var errElapsedHeight = errors.New("elapsed height")
 type heightSub[H header.Header] struct {
 	// height refers to the latest locally available header height
 	// that has been fully verified and inserted into the subjective chain
-	height       uint64 // atomic
+	height       atomic.Uint64
 	heightReqsLk sync.Mutex
 	heightReqs   map[uint64][]chan H
 }
@@ -30,12 +30,12 @@ func newHeightSub[H header.Header]() *heightSub[H] {
 
 // Height reports current height.
 func (hs *heightSub[H]) Height() uint64 {
-	return atomic.LoadUint64(&hs.height)
+	return hs.height.Load()
 }
 
 // SetHeight sets the new head height for heightSub.
 func (hs *heightSub[H]) SetHeight(height uint64) {
-	atomic.StoreUint64(&hs.height, height)
+	hs.height.Store(height)
 }
 
 // Sub subscribes for a header of a given height.

--- a/store/store.go
+++ b/store/store.go
@@ -108,6 +108,9 @@ func newStore[H header.Header](ds datastore.Batching, opts ...Option) (*Store[H]
 }
 
 func (s *Store[H]) Init(ctx context.Context, initial H) error {
+	if s.heightSub.Height() != 0 {
+		return fmt.Errorf("store already initialized")
+	}
 	// trust the given header as the initial head
 	err := s.flush(ctx, initial)
 	if err != nil {
@@ -115,6 +118,7 @@ func (s *Store[H]) Init(ctx context.Context, initial H) error {
 	}
 
 	log.Infow("initialized head", "height", initial.Height(), "hash", initial.Hash())
+	s.heightSub.Pub(initial)
 	return nil
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -112,3 +112,25 @@ func TestStorePendingCacheMiss(t *testing.T) {
 	_, err = store.GetRangeByHeight(ctx, 101, 151)
 	require.NoError(t, err)
 }
+
+func TestBatch_GetByHeightBeforeInit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := test.NewTestSuite(t)
+
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	store, err := NewStore[*test.DummyHeader](ds)
+	require.NoError(t, err)
+
+	err = store.Start(ctx)
+	require.NoError(t, err)
+
+	go func() {
+		_ = store.Init(ctx, suite.Head())
+	}()
+
+	h, err := store.GetByHeight(ctx, 1)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+}


### PR DESCRIPTION
Found while debugging some rollkit tests. Not critical and can only happen in tests 
Supposed to be merged as two separate commits. 