### PR TITLE
refactor: reduce empty response to DEBUG log

### DIFF
--- a/p2p/session.go
+++ b/p2p/session.go
@@ -168,6 +168,7 @@ func (s *session[H]) doRequest(
 			logFn = log.Debugw
 			fallthrough
 		case errEmptyResponse:
+			logFn = log.Debugw
 			stat.decreaseScore()
 		default:
 			s.peerTracker.blockPeer(stat.peerID, err)

--- a/p2p/session.go
+++ b/p2p/session.go
@@ -164,10 +164,7 @@ func (s *session[H]) doRequest(
 		logFn := log.Errorw
 
 		switch err {
-		case header.ErrNotFound:
-			logFn = log.Debugw
-			fallthrough
-		case errEmptyResponse:
+		case header.ErrNotFound, errEmptyResponse:
 			logFn = log.Debugw
 			stat.decreaseScore()
 		default:


### PR DESCRIPTION
Empty responses shouldn't be logged out as an error, it happens often on connection issues.