### PR TITLE
fix(sync): change metric instrument type for total_synced_headers

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -320,6 +320,6 @@ func (s *Syncer[H]) storeHeaders(ctx context.Context, headers ...H) error {
 		return err
 	}
 
-	s.metrics.recordTotalSynced(len(headers))
+	s.metrics.incrementSynced(ctx, len(headers))
 	return nil
 }


### PR DESCRIPTION
From `AsyncGauge` to `SyncCounter`