### PR TITLE
fix(p2p): increase default timeout and provide an option for `TrustedPeersRequestTimeout`

### DIFF
--- a/p2p/options.go
+++ b/p2p/options.go
@@ -167,3 +167,14 @@ func WithChainID[T ClientParameters](chainID string) Option[T] {
 		}
 	}
 }
+
+// WithTrustedPeersRequestTimeout is a functional option that configures the
+// `MaxRangeRequestSize` parameter.
+func WithTrustedPeersRequestTimeout[T ClientParameters](timeout time.Duration) Option[T] {
+	return func(p *T) {
+		switch t := any(p).(type) { //nolint:gocritic
+		case *ClientParameters:
+			t.TrustedPeersRequestTimeout = timeout
+		}
+	}
+}

--- a/p2p/options.go
+++ b/p2p/options.go
@@ -120,7 +120,7 @@ func DefaultClientParameters() ClientParameters {
 	return ClientParameters{
 		MaxHeadersPerRangeRequest:  64,
 		RangeRequestTimeout:        time.Second * 8,
-		TrustedPeersRequestTimeout: time.Millisecond * 300,
+		TrustedPeersRequestTimeout: time.Second * 5,
 	}
 }
 


### PR DESCRIPTION
This was an embarrassingly low timeout, so we set 5 secs now

Also, we never provided an option to rewrite it