### PR TITLE
chore(p2p): remove TrustedPeersRequestTimeout config field

### DIFF
--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -127,8 +127,6 @@ func (ex *Exchange[H]) Head(ctx context.Context) (H, error) {
 	// request head from each trusted peer
 	for _, from := range trustedPeers {
 		go func(from peer.ID) {
-			ctx, cancel := context.WithTimeout(ctx, ex.Params.TrustedPeersRequestTimeout)
-			defer cancel()
 			// request ensures that the result slice will have at least one Header
 			headers, err := ex.request(ctx, from, req)
 			if err != nil {
@@ -262,9 +260,7 @@ func (ex *Exchange[H]) performRequest(
 			default:
 			}
 
-			ctx, cancel := context.WithTimeout(ctx, ex.Params.TrustedPeersRequestTimeout)
 			h, err := ex.request(ctx, peer, req)
-			cancel()
 			if err != nil {
 				reqErr = err
 				log.Debugw("requesting header from trustedPeer failed",

--- a/p2p/options.go
+++ b/p2p/options.go
@@ -107,8 +107,6 @@ type ClientParameters struct {
 	// RangeRequestTimeout defines a timeout after which the session will try to re-request headers
 	// from another peer.
 	RangeRequestTimeout time.Duration
-	// TrustedPeersRequestTimeout a timeout for any request to a trusted peer.
-	TrustedPeersRequestTimeout time.Duration
 	// networkID is a network that will be used to create a protocol.ID
 	networkID string
 	// chainID is an identifier of the chain.
@@ -120,7 +118,6 @@ func DefaultClientParameters() ClientParameters {
 	return ClientParameters{
 		MaxHeadersPerRangeRequest:  64,
 		RangeRequestTimeout:        time.Second * 8,
-		TrustedPeersRequestTimeout: time.Millisecond * 300,
 	}
 }
 
@@ -137,10 +134,6 @@ func (p *ClientParameters) Validate() error {
 	if p.RangeRequestTimeout == 0 {
 		return fmt.Errorf("invalid request timeout for session: "+
 			"%s. %s: %v", greaterThenZero, providedSuffix, p.RangeRequestTimeout)
-	}
-	if p.TrustedPeersRequestTimeout == 0 {
-		return fmt.Errorf("invalid TrustedPeersRequestTimeout: "+
-			"%s. %s: %v", greaterThenZero, providedSuffix, p.TrustedPeersRequestTimeout)
 	}
 	return nil
 }


### PR DESCRIPTION
Implementing this proposal https://github.com/celestiaorg/go-header/pull/28#issuecomment-1509951953 instead of https://github.com/celestiaorg/go-header/pull/28