### PR TITLE
feat: constructors with params

### DIFF
--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -43,6 +43,7 @@ type Exchange[H header.Header] struct {
 	metrics *metrics
 }
 
+// NewExchange instantiates Exchange client with default ClientParameters.
 func NewExchange[H header.Header](
 	host host.Host,
 	peers peer.IDSlice,
@@ -54,6 +55,16 @@ func NewExchange[H header.Header](
 		opt(&params)
 	}
 
+	return NewExchangeWithParams[H](host, peers, connGater, params)
+}
+
+// NewExchangeWithParams instantiates Exchange client with the given ClientParameters.
+func NewExchangeWithParams[H header.Header](
+	host host.Host,
+	peers peer.IDSlice,
+	connGater *conngater.BasicConnectionGater,
+	params ClientParameters,
+) (*Exchange[H], error) {
 	err := params.Validate()
 	if err != nil {
 		return nil, err

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -37,7 +37,7 @@ type ExchangeServer[H header.Header] struct {
 }
 
 // NewExchangeServer returns a new P2P server that handles inbound
-// header-related requests.
+// header-related requests with default params.
 func NewExchangeServer[H header.Header](
 	host host.Host,
 	store header.Store[H],
@@ -47,6 +47,16 @@ func NewExchangeServer[H header.Header](
 	for _, opt := range opts {
 		opt(&params)
 	}
+	return NewExchangeServerWithParams[H](host, store, params)
+}
+
+// NewExchangeServerWithParams returns a new P2P server that handles inbound
+// header-related requests with the given params.
+func NewExchangeServerWithParams[H header.Header](
+	host host.Host,
+	store header.Store[H],
+	params ServerParameters,
+) (*ExchangeServer[H], error) {
 	if err := params.Validate(); err != nil {
 		return nil, err
 	}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -52,7 +52,7 @@ type Syncer[H header.Header] struct {
 	Params *Parameters
 }
 
-// NewSyncer creates a new instance of Syncer.
+// NewSyncer creates a new instance of Syncer with default Parameters.
 func NewSyncer[H header.Header](
 	getter header.Getter[H],
 	store header.Store[H],
@@ -63,6 +63,17 @@ func NewSyncer[H header.Header](
 	for _, opt := range opts {
 		opt(&params)
 	}
+
+	return NewSyncerWithParams[H](getter, store, sub, params)
+}
+
+// NewSyncerWithParams creates a new instance of Syncer with the given Parameters.
+func NewSyncerWithParams[H header.Header](
+	getter header.Getter[H],
+	store header.Store[H],
+	sub header.Subscriber[H],
+	params Parameters,
+) (*Syncer[H], error) {
 	if err := params.Validate(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In #28, we added an option for a configuration field we initially forgot. Subsequently, celestia-node didn't set the configuration field read from a file and it was always the default. 

For power users like celestia-node, options are not useful and actually create problems like the one above(the fact that we didn't make an option is anyway a bug, but it could be mitigated with the following approach). We just want to pass all the parameters as they were read out instead of hassling with each option like we [do right now.](https://github.com/celestiaorg/celestia-node/blob/main/nodebuilder/header/module.go#L45-L48)

This patch adds a new constructor per each component. The ctor just expects already filled and valid Parameters struct. The old ctor with options stays to keep options for less opinionated users and not to break anything.
