### PR TITLE
Feat: add peerstore

### DIFF
--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -70,6 +70,7 @@ func NewExchange[H header.Header](
 			host,
 			connGater,
 			params.peerstore,
+			WithGCCycle(time.Minute*2),
 		),
 		Params: params,
 	}

--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -69,6 +69,7 @@ func NewExchange[H header.Header](
 		peerTracker: newPeerTracker(
 			host,
 			connGater,
+			params.peerstore,
 		),
 		Params: params,
 	}

--- a/p2p/options.go
+++ b/p2p/options.go
@@ -3,6 +3,8 @@ package p2p
 import (
 	"fmt"
 	"time"
+
+	"github.com/celestiaorg/go-header/p2p/peerstore"
 )
 
 // parameters is an interface that encompasses all params needed for
@@ -119,6 +121,8 @@ type ClientParameters struct {
 	networkID string
 	// chainID is an identifier of the chain.
 	chainID string
+	// peerstore is a storage for peers.
+	peerstore peerstore.Peerstore
 }
 
 // DefaultClientParameters returns the default params to configure the store.
@@ -165,6 +169,17 @@ func WithChainID[T ClientParameters](chainID string) Option[T] {
 		switch t := any(p).(type) { //nolint:gocritic
 		case *ClientParameters:
 			t.chainID = chainID
+		}
+	}
+}
+
+// WithPeerPersistence is a functional option that configures the
+// `peerstore` parameter.
+func WithPeerPersistence[T ClientParameters](pstore peerstore.Peerstore) Option[T] {
+	return func(p *T) {
+		switch t := any(p).(type) { //nolint:gocritic
+		case *ClientParameters:
+			t.peerstore = pstore
 		}
 	}
 }

--- a/p2p/peerstore/mock.go
+++ b/p2p/peerstore/mock.go
@@ -1,0 +1,24 @@
+package peerstore
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type mockPeerstore struct {
+	container []peer.AddrInfo
+}
+
+func NewMockPeerstore() Peerstore {
+	return &mockPeerstore{}
+}
+
+func (m *mockPeerstore) Put(ctx context.Context, peers []peer.AddrInfo) error {
+	m.container = peers
+	return nil
+}
+
+func (m *mockPeerstore) Load(ctx context.Context) ([]peer.AddrInfo, error) {
+	return m.container, nil
+}

--- a/p2p/peerstore/peerstore.go
+++ b/p2p/peerstore/peerstore.go
@@ -1,0 +1,70 @@
+package peerstore
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"encoding/json"
+	"fmt"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+type Peerstore interface {
+	Put(context.Context, []peer.AddrInfo) error
+	Load(context.Context) ([]peer.AddrInfo, error)
+}
+
+var (
+	storePrefix = datastore.NewKey("p2p")
+	peersKey    = datastore.NewKey("good_peers")
+
+	log = logging.Logger("module/header/peerstore")
+)
+
+var _ Peerstore = (*peerStore)(nil)
+
+type peerStore struct {
+	ds datastore.Datastore
+}
+
+// newPeerStore wraps the given datastore.Datastore with the `p2p` prefix.
+func NewPeerStore(ds datastore.Datastore) Peerstore {
+	return &peerStore{ds: namespace.Wrap(ds, storePrefix)}
+}
+
+func (s *peerStore) Load(ctx context.Context) ([]peer.AddrInfo, error) {
+	log.Info("Loading peerlist")
+	bs, err := s.ds.Get(ctx, peersKey)
+	if err != nil {
+		return make([]peer.AddrInfo, 0), err
+	}
+
+	peerlist := make([]peer.AddrInfo, 0)
+	err = json.Unmarshal(bs, &peerlist)
+	if err != nil {
+		return make([]peer.AddrInfo, 0), fmt.Errorf("error unmarshalling peerlist: %w", err)
+	}
+
+	log.Info("Loaded peerlist", peerlist)
+	return peerlist, err
+}
+
+func (s *peerStore) Put(ctx context.Context, peerlist []peer.AddrInfo) error {
+	log.Info("Storing peerlist", peerlist)
+
+	bs, err := json.Marshal(peerlist)
+	if err != nil {
+		return fmt.Errorf("marshal checkpoint: %w", err)
+	}
+
+	if err = s.ds.Put(ctx, peersKey, bs); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Overview

Add peerstore to go-header to be used by exchange to store good peers and alleviate the centralization that is the result of relying on bootstrappers only. This is the implementation of the decision [ADR 14](https://github.com/celestiaorg/celestia-node/pull/2024)

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
