### PR TITLE
feat(p2p/idstore): Add PeerIDStore interface

### DIFF
--- a/p2p/idstore/idstore.go
+++ b/p2p/idstore/idstore.go
@@ -1,0 +1,15 @@
+package idstore
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// PeerIDStore is a utility for persisting peer IDs of good peers to a datastore.
+type PeerIDStore interface {
+	// Put stores the given peer IDs.
+	Put(ctx context.Context, peers []peer.ID) error
+	// Load loads the peer IDs from the store.
+	Load(ctx context.Context) ([]peer.ID, error)
+}

--- a/p2p/pidstore.go
+++ b/p2p/pidstore.go
@@ -1,4 +1,4 @@
-package idstore
+package p2p
 
 import (
 	"context"


### PR DESCRIPTION
This PR precedes #36 as we opted for a more generic solution inside of celestia-node that would allow multiple components to leverage the store.

This interface would allow go-header to use celestia-node's implementation inside of the peer tracker.