### PR TITLE
feat(p2p): Add PeerIDStore interface to PeerTracker to store good peers during GC

### DIFF
--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -36,7 +36,7 @@ type Exchange[H header.Header] struct {
 	host       host.Host
 
 	trustedPeers func() peer.IDSlice
-	peerTracker  *peerTracker
+	peerTracker  *PeerTracker
 
 	Params ClientParameters
 
@@ -47,6 +47,7 @@ func NewExchange[H header.Header](
 	host host.Host,
 	peers peer.IDSlice,
 	connGater *conngater.BasicConnectionGater,
+	tracker *PeerTracker,
 	opts ...Option[ClientParameters],
 ) (*Exchange[H], error) {
 	params := DefaultClientParameters()
@@ -60,13 +61,10 @@ func NewExchange[H header.Header](
 	}
 
 	ex := &Exchange[H]{
-		host:       host,
-		protocolID: protocolID(params.networkID),
-		peerTracker: newPeerTracker(
-			host,
-			connGater,
-		),
-		Params: params,
+		host:        host,
+		protocolID:  protocolID(params.networkID),
+		peerTracker: tracker,
+		Params:      params,
 	}
 
 	ex.trustedPeers = func() peer.IDSlice {

--- a/p2p/peer_tracker_test.go
+++ b/p2p/peer_tracker_test.go
@@ -19,7 +19,7 @@ func TestPeerTracker_GC(t *testing.T) {
 	gcCycle = time.Millisecond * 200
 	connGater, err := conngater.NewBasicConnectionGater(sync.MutexWrap(datastore.NewMapDatastore()))
 	require.NoError(t, err)
-	p := newPeerTracker(h[0], connGater)
+	p := NewPeerTracker(h[0], connGater, nil)
 	maxAwaitingTime = time.Millisecond
 	pid1 := peer.ID("peer1")
 	pid2 := peer.ID("peer2")
@@ -48,7 +48,7 @@ func TestPeerTracker_BlockPeer(t *testing.T) {
 	h := createMocknet(t, 2)
 	connGater, err := conngater.NewBasicConnectionGater(sync.MutexWrap(datastore.NewMapDatastore()))
 	require.NoError(t, err)
-	p := newPeerTracker(h[0], connGater)
+	p := NewPeerTracker(h[0], connGater, nil)
 	maxAwaitingTime = time.Millisecond
 	p.blockPeer(h[1].ID(), errors.New("test"))
 	require.Len(t, connGater.ListBlockedPeers(), 1)

--- a/p2p/peer_tracker_test.go
+++ b/p2p/peer_tracker_test.go
@@ -2,12 +2,16 @@ package p2p
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
+	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"github.com/stretchr/testify/assert"
@@ -15,16 +19,27 @@ import (
 )
 
 func TestPeerTracker_GC(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
 	h := createMocknet(t, 1)
+
 	gcCycle = time.Millisecond * 200
+
 	connGater, err := conngater.NewBasicConnectionGater(sync.MutexWrap(datastore.NewMapDatastore()))
 	require.NoError(t, err)
-	p := NewPeerTracker(h[0], connGater, nil)
+
+	pidstore := newDummyPIDStore()
+	p := NewPeerTracker(h[0], connGater, pidstore)
+
 	maxAwaitingTime = time.Millisecond
-	pid1 := peer.ID("peer1")
-	pid2 := peer.ID("peer2")
-	pid3 := peer.ID("peer3")
-	pid4 := peer.ID("peer4")
+
+	peerlist := generateRandomPeerlist(t, 4)
+	pid1 := peerlist[0]
+	pid2 := peerlist[1]
+	pid3 := peerlist[2]
+	pid4 := peerlist[3]
+
 	p.trackedPeers[pid1] = &peerStat{peerID: pid1, peerScore: 0.5}
 	p.trackedPeers[pid2] = &peerStat{peerID: pid2, peerScore: 10}
 	p.disconnectedPeers[pid3] = &peerStat{peerID: pid3, pruneDeadline: time.Now()}
@@ -35,13 +50,18 @@ func TestPeerTracker_GC(t *testing.T) {
 	go p.track()
 	go p.gc()
 
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Millisecond * 500)
 
-	err = p.stop(context.Background())
+	err = p.stop(ctx)
 	require.NoError(t, err)
 
 	require.Nil(t, p.trackedPeers[pid1])
 	require.Nil(t, p.disconnectedPeers[pid3])
+
+	// ensure good peers were dumped to store
+	peers, err := pidstore.Load(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(peers))
 }
 
 func TestPeerTracker_BlockPeer(t *testing.T) {
@@ -53,4 +73,52 @@ func TestPeerTracker_BlockPeer(t *testing.T) {
 	p.blockPeer(h[1].ID(), errors.New("test"))
 	require.Len(t, connGater.ListBlockedPeers(), 1)
 	require.True(t, connGater.ListBlockedPeers()[0] == h[1].ID())
+}
+
+type dummyPIDStore struct {
+	ds  datastore.Datastore
+	key datastore.Key
+}
+
+func newDummyPIDStore() PeerIDStore {
+	return &dummyPIDStore{
+		key: datastore.NewKey("peers"),
+		ds:  sync.MutexWrap(datastore.NewMapDatastore()),
+	}
+}
+
+func (d *dummyPIDStore) Put(ctx context.Context, peers []peer.ID) error {
+	bin, err := json.Marshal(peers)
+	if err != nil {
+		return err
+	}
+	return d.ds.Put(ctx, d.key, bin)
+}
+
+func (d *dummyPIDStore) Load(ctx context.Context) ([]peer.ID, error) {
+	bin, err := d.ds.Get(ctx, d.key)
+	if err != nil {
+		return nil, err
+	}
+
+	var peers []peer.ID
+	err = json.Unmarshal(bin, &peers)
+	return peers, err
+}
+
+func generateRandomPeerlist(t *testing.T, length int) []peer.ID {
+	peerlist := make([]peer.ID, length)
+	for i := range peerlist {
+		key, err := rsa.GenerateKey(rand.Reader, 2096)
+		require.NoError(t, err)
+
+		_, pubkey, err := crypto.KeyPairFromStdKey(key)
+		require.NoError(t, err)
+
+		peerID, err := peer.IDFromPublicKey(pubkey)
+		require.NoError(t, err)
+
+		peerlist[i] = peerID
+	}
+	return peerlist
 }

--- a/p2p/session.go
+++ b/p2p/session.go
@@ -33,10 +33,10 @@ type session[H header.Header] struct {
 	protocolID protocol.ID
 	queue      *peerQueue
 	// peerTracker contains discovered peers with records that describes their activity.
-	peerTracker *peerTracker
+	peerTracker *PeerTracker
 
-	// `from` is set when additional validation for range is needed.
 	// Otherwise, it will be nil.
+	// `from` is set when additional validation for range is needed.
 	from           H
 	requestTimeout time.Duration
 
@@ -48,7 +48,7 @@ type session[H header.Header] struct {
 func newSession[H header.Header](
 	ctx context.Context,
 	h host.Host,
-	peerTracker *peerTracker,
+	peerTracker *PeerTracker,
 	protocolID protocol.ID,
 	requestTimeout time.Duration,
 	options ...option[H],

--- a/p2p/session_test.go
+++ b/p2p/session_test.go
@@ -28,7 +28,7 @@ func Test_Validate(t *testing.T) {
 	ses := newSession(
 		context.Background(),
 		nil,
-		&peerTracker{trackedPeers: make(map[peer.ID]*peerStat)},
+		&PeerTracker{trackedPeers: make(map[peer.ID]*peerStat)},
 		"", time.Second,
 		withValidation(head),
 	)
@@ -45,7 +45,7 @@ func Test_ValidateFails(t *testing.T) {
 	ses := newSession(
 		context.Background(),
 		nil,
-		&peerTracker{trackedPeers: make(map[peer.ID]*peerStat)},
+		&PeerTracker{trackedPeers: make(map[peer.ID]*peerStat)},
 		"", time.Second,
 		withValidation(head),
 	)


### PR DESCRIPTION
This PR does a few things: 
* exports peer tracker and extends its constructor to take a PeerIDStore 
* after GC, peer tracker will store the remaining "good peers" to the given PeerIDStore via `dumpPeers` if a peerIDStore was given

This allows up-to-date persistence of good peers for the peer tracker that it can later use to bootstrap itself on re-start.

**Note**

Constructor for p2p.Exchange now takes a peer tracker.