### PR TITLE
fix(sync): fix two synchronization issues

### DIFF
--- a/p2p/exchange_test.go
+++ b/p2p/exchange_test.go
@@ -18,11 +18,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/go-libp2p-messenger/serde"
-
 	"github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/go-header/headertest"
 	p2p_pb "github.com/celestiaorg/go-header/p2p/pb"
+	"github.com/celestiaorg/go-libp2p-messenger/serde"
 )
 
 const networkID = "private"

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -44,6 +44,8 @@ type Syncer[H header.Header] struct {
 	triggerSync chan struct{}
 	// pending keeps ranges of valid new network headers awaiting to be appended to store
 	pending ranges[H]
+	// incomingMu ensures only one incoming network head candidate is processed at the time
+	incomingMu sync.Mutex
 
 	// controls lifecycle for syncLoop
 	ctx    context.Context

--- a/sync/sync_getter.go
+++ b/sync/sync_getter.go
@@ -3,29 +3,50 @@ package sync
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/celestiaorg/go-header"
 )
 
 // syncGetter is a Getter wrapper that ensure only one Head call happens at the time
 type syncGetter[H header.Header] struct {
+	getterLk   sync.RWMutex
+	isGetterLk atomic.Bool
 	header.Getter[H]
-
-	headLk  sync.RWMutex
-	headErr error
-	head    H
 }
 
-func (se *syncGetter[H]) Head(ctx context.Context) (H, error) {
-	// the lock construction here ensures only one routine calling Head at a time
+// Lock locks the getter for single user.
+// Reports 'true' if the lock was held by the current routine.
+// Does not require unlocking on 'false'.
+func (sg *syncGetter[H]) Lock() bool {
+	// the lock construction here ensures only one routine is freed at a time
 	// while others wait via Rlock
-	if !se.headLk.TryLock() {
-		se.headLk.RLock()
-		defer se.headLk.RUnlock()
-		return se.head, se.headErr
+	locked := sg.getterLk.TryLock()
+	if !locked {
+		sg.getterLk.RLock()
+		defer sg.getterLk.RUnlock()
+		return false
 	}
-	defer se.headLk.Unlock()
+	sg.isGetterLk.Store(locked)
+	return locked
+}
 
-	se.head, se.headErr = se.Getter.Head(ctx)
-	return se.head, se.headErr
+// Unlock unlocks the getter.
+func (sg *syncGetter[H]) Unlock() {
+	sg.checkLock("Unlock without preceding Lock on syncGetter")
+	sg.getterLk.Unlock()
+	sg.isGetterLk.Store(false)
+}
+
+// Head must be called with held Lock.
+func (sg *syncGetter[H]) Head(ctx context.Context) (H, error) {
+	sg.checkLock("Head without preceding Lock on syncGetter")
+	return sg.Getter.Head(ctx)
+}
+
+// checkLock ensures api safety
+func (sg *syncGetter[H]) checkLock(msg string) {
+	if !sg.isGetterLk.Load() {
+		panic(msg)
+	}
 }

--- a/sync/sync_getter_test.go
+++ b/sync/sync_getter_test.go
@@ -26,6 +26,10 @@ func TestSyncGetterHead(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			if !sex.Lock() {
+				return
+			}
+			defer sex.Unlock()
 			h, err := sex.Head(ctx)
 			if h != nil || err != errFakeHead {
 				t.Fail()

--- a/sync/sync_head_test.go
+++ b/sync/sync_head_test.go
@@ -1,0 +1,46 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/go-header/headertest"
+)
+
+func TestSyncer_incomingNetworkHeadRaces(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	store := headertest.NewStore[*headertest.DummyHeader](t, suite, 1)
+	syncer, err := NewSyncer[*headertest.DummyHeader](
+		store,
+		store,
+		headertest.NewDummySubscriber(),
+	)
+	require.NoError(t, err)
+
+	incoming := suite.NextHeader()
+
+	var hits atomic.Uint32
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if syncer.incomingNetworkHead(ctx, incoming) == pubsub.ValidationAccept {
+				hits.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.EqualValues(t, 1, hits.Load())
+}


### PR DESCRIPTION
Closes: #67 
The issues:
* The syncGetter usage was racy. It had working single-flight protection, but all the routines awaiting the result returned all together and set the new header, causing the Store to receive the same headers awaited routines amount of time. 
* The race between headers received from gossip and requested by Head callers.