### PR TITLE
fix(store): make storePrefix actually optional

### DIFF
--- a/store/options.go
+++ b/store/options.go
@@ -23,6 +23,7 @@ type Parameters struct {
 	WriteBatchSize int
 
 	// storePrefix defines the prefix used to wrap the store
+	// OPTIONAL
 	storePrefix datastore.Key
 }
 
@@ -32,7 +33,6 @@ func DefaultParameters() Parameters {
 		StoreCacheSize: 4096,
 		IndexCacheSize: 16384,
 		WriteBatchSize: 2048,
-		storePrefix:    datastore.NewKey("headers"),
 	}
 }
 
@@ -47,9 +47,6 @@ func (p *Parameters) Validate() error {
 	}
 	if p.WriteBatchSize <= 0 {
 		return fmt.Errorf("invalid batch size:%s", errSuffix)
-	}
-	if len(p.storePrefix.Bytes()) == 0 {
-		return fmt.Errorf("invalid store prefix: prefix cannot be empty")
 	}
 	return nil
 }

--- a/store/store.go
+++ b/store/store.go
@@ -17,6 +17,8 @@ import (
 var log = logging.Logger("header/store")
 
 var (
+	// defaultStorePrefix defines default datastore prefix
+	defaultStorePrefix = datastore.NewKey("headers")
 	// errStoppedStore is returned for attempted operations on a stopped store
 	errStoppedStore = errors.New("stopped store")
 )
@@ -89,7 +91,12 @@ func newStore[H header.Header](ds datastore.Batching, opts ...Option) (*Store[H]
 		return nil, fmt.Errorf("failed to create index cache: %w", err)
 	}
 
-	wrappedStore := namespace.Wrap(ds, params.storePrefix)
+	prefix := params.storePrefix
+	if len(prefix.String()) == 0 {
+		prefix = defaultStorePrefix
+	}
+
+	wrappedStore := namespace.Wrap(ds, prefix)
 	index, err := newHeightIndexer[H](wrappedStore, params.IndexCacheSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create height indexer: %w", err)


### PR DESCRIPTION
When we set the default value on the private config field while requiring it, we brake the serialization of the Parameters struct. 
Particularly when we deserialize Parameters, the `storePrefix` is empty while the validation requires it. Because it's private, there is also no way to set it on the node, so this fix is necessary. This is also good learning that we should be cautious while introducing such optinonals