### PR TITLE
bugfix: fix panic in GetVerifiedRange

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -242,7 +242,7 @@ func (s *Store[H]) GetByHeight(ctx context.Context, height uint64) (H, error) {
 func (s *Store[H]) GetRangeByHeight(ctx context.Context, from, to uint64) ([]H, error) {
 	// as the requested range is non-inclusive in the end[from;to), we need to compare
 	// `from` with `to-1`
-	if from >= to-1 {
+	if from > to-1 {
 		return nil, fmt.Errorf("header/store: invalid range(%d,%d)", from, to-1)
 	}
 	h, err := s.GetByHeight(ctx, to-1)

--- a/store/store.go
+++ b/store/store.go
@@ -264,10 +264,13 @@ func (s *Store[H]) GetVerifiedRange(
 	from H,
 	to uint64,
 ) ([]H, error) {
-	if uint64(from.Height()) >= to {
-		return nil, fmt.Errorf("header/store: invalid range(%d,%d)", from.Height(), to)
+	// as the requested range is non-inclusive in both sides(from;to), we need to compare
+	// `from.Height()+1` with `to`
+	requestedHeight := uint64(from.Height() + 1)
+	if requestedHeight >= to {
+		return nil, fmt.Errorf("header/store: invalid range(%d,%d)", requestedHeight, to)
 	}
-	headers, err := s.GetRangeByHeight(ctx, uint64(from.Height())+1, to)
+	headers, err := s.GetRangeByHeight(ctx, requestedHeight, to)
 	if err != nil {
 		return nil, err
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -70,7 +70,12 @@ func TestStore(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, out)
 
-	out, err = store.GetRangeByHeight(ctx, 2, 3)
+	out, err = store.GetVerifiedRange(ctx, h, 4)
+	require.NoError(t, err)
+	assert.NotNil(t, out)
+	assert.Len(t, out, 1)
+
+	out, err = store.GetRangeByHeight(ctx, 2, 2)
 	require.Error(t, err)
 	assert.Nil(t, out)
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -64,6 +64,12 @@ func TestStore(t *testing.T) {
 	err = store.Stop(ctx)
 	require.NoError(t, err)
 
+	h, err = store.GetByHeight(ctx, 2)
+	require.NoError(t, err)
+	out, err = store.GetVerifiedRange(ctx, h, 3)
+	require.Error(t, err)
+	assert.Nil(t, out)
+
 	// check that the store can be successfully started after previous stop
 	// with all data being flushed.
 	store, err = NewStore[*headertest.DummyHeader](ds)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -70,6 +70,10 @@ func TestStore(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, out)
 
+	out, err = store.GetRangeByHeight(ctx, 2, 3)
+	require.Error(t, err)
+	assert.Nil(t, out)
+
 	// check that the store can be successfully started after previous stop
 	// with all data being flushed.
 	store, err = NewStore[*headertest.DummyHeader](ds)


### PR DESCRIPTION
## Overview
Fix panic by reworking the condition that compares `from` and `to`
Closes #70 

## Checklist
- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
