### PR TITLE
fix(store): ensure Store can be initialized with any height

### DIFF
--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -83,7 +83,7 @@ func (hs *heightSub[H]) Pub(headers ...H) {
 
 	height := hs.Height()
 	from, to := uint64(headers[0].Height()), uint64(headers[ln-1].Height())
-	if height+1 != from {
+	if height+1 != from && height != 0 { // height != 0 is needed to enable init from any height and not only 1
 		log.Fatalf("PLEASE FILE A BUG REPORT: headers given to the heightSub are in the wrong order: expected %d, got %d", height+1, from)
 		return
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -134,3 +134,17 @@ func TestBatch_GetByHeightBeforeInit(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, h)
 }
+
+func TestStoreInit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	store, err := NewStore[*headertest.DummyHeader](ds)
+	require.NoError(t, err)
+
+	headers := suite.GenDummyHeaders(10)
+	err = store.Init(ctx, headers[len(headers)-1]) // init should work with any height, not only 1
+	require.NoError(t, err)
+}


### PR DESCRIPTION
We should allow the Store to be started from any desired height, not only 1.