### PR TITLE
chore(store): Parameters marshalling rountrip test

### DIFF
--- a/store/options_test.go
+++ b/store/options_test.go
@@ -1,9 +1,11 @@
 package store
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOptionsWithParams(t *testing.T) {
@@ -16,4 +18,17 @@ func TestOptionsWithParams(t *testing.T) {
 
 	opt(&params)
 	assert.Equal(t, size, params.StoreCacheSize)
+}
+
+func TestDefaultParamsMarshalRountrip(t *testing.T) {
+	paramsIn := DefaultParameters()
+	paramsOut := Parameters{}
+
+	bytes, err := json.Marshal(paramsIn)
+	require.NoError(t, err)
+
+	err = json.Unmarshal(bytes, &paramsOut)
+	require.NoError(t, err)
+
+	assert.Equal(t, paramsIn, paramsOut)
 }


### PR DESCRIPTION
If this test existed, the bug fixed by #69 wouldn't happen 