### PR TITLE
test(sync): Test case where bad header is set as sync target

### DIFF
--- a/headertest/dummy_header.go
+++ b/headertest/dummy_header.go
@@ -27,6 +27,8 @@ type DummyHeader struct {
 	Raw
 
 	hash header.Hash
+
+	VerifyFailure bool // TODO
 }
 
 func RandDummyHeader(t *testing.T) *DummyHeader {
@@ -39,6 +41,7 @@ func RandDummyHeader(t *testing.T) *DummyHeader {
 			Time:         time.Now().UTC(),
 		},
 		nil,
+		false,
 	}
 	err := dh.rehash()
 	if err != nil {
@@ -100,6 +103,10 @@ func (d *DummyHeader) IsExpired(period time.Duration) bool {
 }
 
 func (d *DummyHeader) Verify(header header.Header) error {
+	if dummy, _ := header.(*DummyHeader); dummy.VerifyFailure {
+		return fmt.Errorf("bad header") // TODO
+	}
+
 	epsilon := 10 * time.Second
 	if header.Time().After(time.Now().Add(epsilon)) {
 		return fmt.Errorf("header Time too far in the future")

--- a/headertest/dummy_header.go
+++ b/headertest/dummy_header.go
@@ -28,7 +28,9 @@ type DummyHeader struct {
 
 	hash header.Hash
 
-	VerifyFailure bool // TODO
+	// VerifyFailure allows for testing scenarios where a header would fail
+	// verification. When set to true, it forces a failure.
+	VerifyFailure bool
 }
 
 func RandDummyHeader(t *testing.T) *DummyHeader {
@@ -104,7 +106,7 @@ func (d *DummyHeader) IsExpired(period time.Duration) bool {
 
 func (d *DummyHeader) Verify(header header.Header) error {
 	if dummy, _ := header.(*DummyHeader); dummy.VerifyFailure {
-		return fmt.Errorf("bad header") // TODO
+		return fmt.Errorf("header at height %d failed verification", header.Height())
 	}
 
 	epsilon := 10 * time.Second

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -357,7 +357,10 @@ func TestSync_InvalidSyncTarget(t *testing.T) {
 	expectedHead, err := remoteStore.Head(ctx)
 	require.NoError(t, err)
 	syncer.incomingNetworkHead(ctx, expectedHead)
-	// wait for syncer to finish
+
+	// wait for syncer to finish (give it a bit of time to register
+	// new job with new sync target)
+	time.Sleep(100 * time.Millisecond)
 	err = syncer.SyncWait(ctx)
 	require.NoError(t, err)
 
@@ -373,8 +376,8 @@ func TestSync_InvalidSyncTarget(t *testing.T) {
 	syncHead, err := syncer.Head(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, expectedHead.Height()-1, storeHead.Height()) // head might not be applied to store yet
 	require.Equal(t, expectedHead.Height(), syncHead.Height())
+	require.Equal(t, expectedHead.Height(), storeHead.Height())
 }
 
 type delayedGetter[H header.Header] struct {


### PR DESCRIPTION
Implement test for the case where a bad header is set as a sync target and ensure that syncer can discard and recover from it.