### PR TITLE
refactor(p2p)!: PIDStore interface should take `peer.AddrInfo` and not `peer.ID`

### DIFF
--- a/p2p/peer_tracker.go
+++ b/p2p/peer_tracker.go
@@ -201,11 +201,11 @@ func (p *peerTracker) dumpPeers(ctx context.Context) {
 		return
 	}
 
-	peers := make([]peer.ID, 0, len(p.trackedPeers))
+	peers := make([]peer.AddrInfo, 0, len(p.trackedPeers))
 
 	p.peerLk.RLock()
 	for id := range p.trackedPeers {
-		peers = append(peers, id)
+		peers = append(peers, p.host.Peerstore().PeerInfo(id))
 	}
 	p.peerLk.RUnlock()
 

--- a/p2p/peer_tracker_test.go
+++ b/p2p/peer_tracker_test.go
@@ -85,7 +85,7 @@ func newDummyPIDStore() PeerIDStore {
 	}
 }
 
-func (d *dummyPIDStore) Put(ctx context.Context, peers []peer.ID) error {
+func (d *dummyPIDStore) Put(ctx context.Context, peers []peer.AddrInfo) error {
 	bin, err := json.Marshal(peers)
 	if err != nil {
 		return err
@@ -93,13 +93,13 @@ func (d *dummyPIDStore) Put(ctx context.Context, peers []peer.ID) error {
 	return d.ds.Put(ctx, d.key, bin)
 }
 
-func (d *dummyPIDStore) Load(ctx context.Context) ([]peer.ID, error) {
+func (d *dummyPIDStore) Load(ctx context.Context) ([]peer.AddrInfo, error) {
 	bin, err := d.ds.Get(ctx, d.key)
 	if err != nil {
 		return nil, err
 	}
 
-	var peers []peer.ID
+	var peers []peer.AddrInfo
 	err = json.Unmarshal(bin, &peers)
 	return peers, err
 }

--- a/p2p/pidstore.go
+++ b/p2p/pidstore.go
@@ -6,10 +6,11 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-// PeerIDStore is a utility for persisting peer IDs of good peers to a datastore.
+// PeerIDStore is a utility for persisting peer AddrInfo of good peers to a
+// datastore.
 type PeerIDStore interface {
-	// Put stores the given peer IDs.
-	Put(ctx context.Context, peers []peer.ID) error
-	// Load loads the peer IDs from the store.
-	Load(ctx context.Context) ([]peer.ID, error)
+	// Put stores the given peers' AddrInfo.
+	Put(ctx context.Context, peers []peer.AddrInfo) error
+	// Load loads the peers' AddrInfo from the store.
+	Load(ctx context.Context) ([]peer.AddrInfo, error)
 }


### PR DESCRIPTION
The whole original point of using an on-disk peerstore is to quickly bootstrap the node with previously-seen good peers such that it can use them as quickly as possible.

If we only store the `peer.ID`, the host will have no addr information on that peer so it will not be able to connect to it early on until it actually discovers that peer later on and then gets its address information.

**While this PR is breaking**, I doubt anyone except celestia-node is using the pidstore interface at all so hopefully this isn't too intrusive.