### PR TITLE
refactor!: Subcriber: AddValidator -> SetVerifier

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,11 +2,19 @@ package header
 
 import "fmt"
 
-// VerifyError is thrown on during Verify if it fails.
+// VerifyError is thrown during for Headers failed verification.
 type VerifyError struct {
+	// Reason why verification failed as inner error.
 	Reason error
+	// Uncertain signals that the was not enough information to conclude a Header is correct or not.
+	// May happen with recent Headers during unfinished historical sync or because of local errors.
+	Uncertain bool
 }
 
 func (vr *VerifyError) Error() string {
 	return fmt.Sprintf("header: verify: %s", vr.Reason.Error())
+}
+
+func (vr *VerifyError) Unwrap() error {
+	return vr.Reason
 }

--- a/headertest/subscriber.go
+++ b/headertest/subscriber.go
@@ -3,8 +3,6 @@ package headertest
 import (
 	"context"
 
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-
 	"github.com/celestiaorg/go-header"
 )
 
@@ -16,7 +14,7 @@ func NewDummySubscriber() *Subscriber[*DummyHeader] {
 	return &Subscriber[*DummyHeader]{}
 }
 
-func (mhs *Subscriber[H]) AddValidator(func(context.Context, H) pubsub.ValidationResult) error {
+func (mhs *Subscriber[H]) SetVerifier(func(context.Context, H) error) error {
 	return nil
 }
 

--- a/interface.go
+++ b/interface.go
@@ -20,15 +20,14 @@ type Subscriber[H Header] interface {
 	// Subscribe creates long-living Subscription for validated Headers.
 	// Multiple Subscriptions can be created.
 	Subscribe() (Subscription[H], error)
-	// AddValidator registers a Validator for all Subscriptions.
-	// Registered Validators screen Headers for their validity
-	// before they are sent through Subscriptions.
-	// Multiple validators can be registered.
-	AddValidator(func(context.Context, H) pubsub.ValidationResult) error
+	// SetVerifier registers verification func for all Subscriptions.
+	// Registered func screens incoming headers
+	// before they are forwarded to Subscriptions.
+	// Only one func can be set.
+	SetVerifier(func(context.Context, H) error) error
 }
 
-// Subscription can retrieve the next Header from the
-// network.
+// Subscription listens for new Headers.
 type Subscription[H Header] interface {
 	// NextHeader returns the newest verified and valid Header
 	// in the network.

--- a/p2p/subscriber.go
+++ b/p2p/subscriber.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -52,8 +53,9 @@ func (p *Subscriber[H]) Stop(context.Context) error {
 	return p.topic.Close()
 }
 
-// AddValidator applies basic pubsub validator for the topic.
-func (p *Subscriber[H]) AddValidator(val func(context.Context, H) pubsub.ValidationResult) error {
+// SetVerifier set given verification func as Header PubSub topic validator
+// Does not punish peers if *header.VerifyError is given with Uncertain set to true.
+func (p *Subscriber[H]) SetVerifier(val func(context.Context, H) error) error {
 	pval := func(ctx context.Context, p peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
 		var empty H
 		maybeHead := empty.New()
@@ -65,7 +67,20 @@ func (p *Subscriber[H]) AddValidator(val func(context.Context, H) pubsub.Validat
 			return pubsub.ValidationReject
 		}
 		msg.ValidatorData = maybeHead
-		return val(ctx, maybeHead.(H))
+
+		var verErr *header.VerifyError
+		err = val(ctx, maybeHead.(H))
+		switch {
+		case err == nil:
+			return pubsub.ValidationAccept
+		case errors.As(err, &verErr):
+			if verErr.Uncertain {
+				return pubsub.ValidationIgnore
+			}
+			fallthrough
+		default:
+			return pubsub.ValidationReject
+		}
 	}
 	return p.pubsub.RegisterTopicValidator(p.pubsubTopicID, pval)
 }

--- a/p2p/subscriber.go
+++ b/p2p/subscriber.go
@@ -73,11 +73,8 @@ func (p *Subscriber[H]) SetVerifier(val func(context.Context, H) error) error {
 		switch {
 		case err == nil:
 			return pubsub.ValidationAccept
-		case errors.As(err, &verErr):
-			if verErr.Uncertain {
-				return pubsub.ValidationIgnore
-			}
-			fallthrough
+		case errors.As(err, &verErr) && verErr.Uncertain:
+			return pubsub.ValidationIgnore
 		default:
 			return pubsub.ValidationReject
 		}

--- a/p2p/subscription_test.go
+++ b/p2p/subscription_test.go
@@ -66,9 +66,11 @@ func TestSubscriber(t *testing.T) {
 	_, err = p2pSub2.Subscribe()
 	require.NoError(t, err)
 
-	p2pSub1.AddValidator(func(context.Context, *headertest.DummyHeader) pubsub.ValidationResult { //nolint:errcheck
-		return pubsub.ValidationAccept
+	err = p2pSub1.SetVerifier(func(context.Context, *headertest.DummyHeader) error {
+		return nil
 	})
+	require.NoError(t, err)
+
 	subscription, err := p2pSub1.Subscribe()
 	require.NoError(t, err)
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -83,7 +83,7 @@ func (s *Syncer[H]) Start(ctx context.Context) error {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	// register validator for header subscriptions
 	// syncer does not subscribe itself and syncs headers together with validation
-	err := s.sub.AddValidator(s.incomingNetworkHead)
+	err := s.sub.SetVerifier(s.incomingNetworkHead)
 	if err != nil {
 		return err
 	}

--- a/sync/sync_head_test.go
+++ b/sync/sync_head_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	sync2 "github.com/ipfs/go-datastore/sync"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -41,7 +40,7 @@ func TestSyncer_incomingNetworkHeadRaces(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if syncer.incomingNetworkHead(ctx, incoming) == pubsub.ValidationAccept {
+			if syncer.incomingNetworkHead(ctx, incoming) == nil {
 				hits.Add(1)
 			}
 		}()


### PR DESCRIPTION
* Verifier is the more correct term to use for stateful verification
* Set because in fact we currently allow only one verification func
* Remove dependency pubsub to support returning header.VerifyError

NOTE: This breakage does not affect anyone as the only user of SetVerifier is Syncer which is updated in this PR