### PR TITLE
fix: ensure header.Validate is called by the lib 

### DIFF
--- a/header.go
+++ b/header.go
@@ -8,10 +8,13 @@ import (
 // Header abstracts all methods required to perform header sync.
 type Header interface {
 	// New creates new instance of a header.
+	// It exists to overcome limitation of Go's type system.
+	// See:
+	//https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#pointer-method-example
 	New() Header
 	// IsZero reports whether Header is a zero value of it's concrete type.
 	IsZero() bool
-	// ChainID returns identifier of the chain (ChainID).
+	// ChainID returns identifier of the chain.
 	ChainID() string
 	// Hash returns hash of a header.
 	Hash() Hash
@@ -23,9 +26,14 @@ type Header interface {
 	Time() time.Time
 	// Verify validates given untrusted Header against trusted Header.
 	Verify(Header) error
-	// Validate performs basic validation to check for missed/incorrect fields.
+	// Validate performs stateless validation to check for missed/incorrect fields.
 	Validate() error
 
 	encoding.BinaryMarshaler
 	encoding.BinaryUnmarshaler
+}
+
+// New is a generic Header constructor.
+func New[H Header]() (h H) {
+	return h.New().(H)
 }

--- a/p2p/session.go
+++ b/p2p/session.go
@@ -159,7 +159,7 @@ func (s *session[H]) doRequest(
 		log.Debugw("requesting headers from peer failed", "peer", stat.peerID, "err", err)
 	}
 
-	h, err := s.processResponse(r)
+	h, err := s.processResponses(r)
 	if err != nil {
 		logFn := log.Errorw
 
@@ -217,18 +217,18 @@ func (s *session[H]) doRequest(
 }
 
 // processResponses converts HeaderResponse to Header.
-func (s *session[H]) processResponse(responses []*p2p_pb.HeaderResponse) ([]H, error) {
+func (s *session[H]) processResponses(responses []*p2p_pb.HeaderResponse) ([]H, error) {
 	hdrs, err := processResponses[H](responses)
 	if err != nil {
 		return nil, err
 	}
 
-	return hdrs, s.validate(hdrs)
+	return hdrs, s.verify(hdrs)
 }
 
-// validate checks that the received range of headers is adjacent and is valid against the provided
+// verify checks that the received range of headers is adjacent and is valid against the provided
 // header.
-func (s *session[H]) validate(headers []H) error {
+func (s *session[H]) verify(headers []H) error {
 	// if `s.from` is empty, then additional validation for the header`s range is not needed.
 	if s.from.IsZero() {
 		return nil

--- a/p2p/session_test.go
+++ b/p2p/session_test.go
@@ -34,7 +34,7 @@ func Test_Validate(t *testing.T) {
 	)
 
 	headers := suite.GenDummyHeaders(5)
-	err := ses.validate(headers)
+	err := ses.verify(headers)
 	assert.NoError(t, err)
 }
 
@@ -53,6 +53,6 @@ func Test_ValidateFails(t *testing.T) {
 	headers := suite.GenDummyHeaders(5)
 	// break adjacency
 	headers[2] = headers[4]
-	err := ses.validate(headers)
+	err := ses.verify(headers)
 	assert.Error(t, err)
 }

--- a/store/init.go
+++ b/store/init.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 
 	"github.com/celestiaorg/go-header"
 )
@@ -10,10 +11,10 @@ import (
 // it initializes the Store by requesting the header with the given hash.
 func Init[H header.Header](ctx context.Context, store header.Store[H], ex header.Exchange[H], hash header.Hash) error {
 	_, err := store.Head(ctx)
-	switch err {
+	switch {
 	default:
 		return err
-	case header.ErrNoHead:
+	case errors.Is(err, header.ErrNoHead):
 		initial, err := ex.Get(ctx, hash)
 		if err != nil {
 			return err

--- a/store/store.go
+++ b/store/store.go
@@ -166,12 +166,12 @@ func (s *Store[H]) Head(ctx context.Context, _ ...header.HeadOption) (H, error) 
 
 	var zero H
 	head, err = s.readHead(ctx)
-	switch err {
+	switch {
 	default:
 		return zero, err
-	case datastore.ErrNotFound, header.ErrNotFound:
+	case errors.Is(err, datastore.ErrNotFound), errors.Is(err, header.ErrNotFound):
 		return zero, header.ErrNoHead
-	case nil:
+	case err == nil:
 		s.heightSub.SetHeight(uint64(head.Height()))
 		log.Infow("loaded head", "height", head.Height(), "hash", head.Hash())
 		return head, nil


### PR DESCRIPTION
Header implementations should not call Validate themselves as the lib now controls it.

Additionally, we unify the response processing code and Header constructor.

Closes #78
Based on #88 