### PR TITLE
fix(sync): Allow some more slack for recency estimation

### DIFF
--- a/sync/options.go
+++ b/sync/options.go
@@ -34,8 +34,7 @@ type Parameters struct {
 // DefaultParameters returns the default params to configure the syncer.
 func DefaultParameters() Parameters {
 	return Parameters{
-		TrustingPeriod:   168 * time.Hour,
-		recencyThreshold: time.Second * 20, // this default is based on a block time of 15 seconds
+		TrustingPeriod: 168 * time.Hour,
 	}
 }
 

--- a/sync/options.go
+++ b/sync/options.go
@@ -26,12 +26,16 @@ type Parameters struct {
 	// Keeping it private to disable serialization for it.
 	// default value is set to 0 so syncer will constantly request networking head.
 	blockTime time.Duration
+	// recencyThreshold describes the time period for which a header is
+	// considered "recent". The default is blockTime + 5 seconds.
+	recencyThreshold time.Duration
 }
 
 // DefaultParameters returns the default params to configure the syncer.
 func DefaultParameters() Parameters {
 	return Parameters{
-		TrustingPeriod: 168 * time.Hour,
+		TrustingPeriod:   168 * time.Hour,
+		recencyThreshold: time.Second * 20, // this default is based on a block time of 15 seconds
 	}
 }
 
@@ -47,6 +51,14 @@ func (p *Parameters) Validate() error {
 func WithBlockTime(duration time.Duration) Options {
 	return func(p *Parameters) {
 		p.blockTime = duration
+	}
+}
+
+// WithRecencyThreshold is a functional option that configures the
+// `recencyThreshold` parameter.
+func WithRecencyThreshold(threshold time.Duration) Options {
+	return func(p *Parameters) {
+		p.recencyThreshold = threshold
 	}
 }
 

--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -19,7 +19,7 @@ func (s *Syncer[H]) Head(ctx context.Context, _ ...header.HeadOption[H]) (H, err
 		return sbjHead, err
 	}
 	// if subjective header is recent enough (relative to the network's block time) - just use it
-	if isRecent(sbjHead, s.Params.blockTime) {
+	if isRecent(sbjHead, s.Params.recencyThreshold) {
 		return sbjHead, nil
 	}
 	// otherwise, request head from the network
@@ -98,7 +98,7 @@ func (s *Syncer[H]) subjectiveHead(ctx context.Context) (H, error) {
 		return trustHead, nil
 	case isExpired(trustHead, s.Params.TrustingPeriod):
 		log.Warnw("subjective initialization with an expired header", "height", trustHead.Height())
-	case !isRecent(trustHead, s.Params.blockTime):
+	case !isRecent(trustHead, s.Params.recencyThreshold):
 		log.Warnw("subjective initialization with an old header", "height", trustHead.Height())
 	}
 	log.Warn("trusted peer is out of sync")

--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -190,6 +190,12 @@ func isExpired[H header.Header[H]](header H, period time.Duration) bool {
 }
 
 // isRecent checks if header is recent against the given blockTime.
-func isRecent[H header.Header[H]](header H, blockTime time.Duration) bool {
-	return time.Since(header.Time()) <= blockTime+blockTime/2 // add half block time drift
+func isRecent[H header.Header[H]](header H, recencyThreshold time.Duration) bool {
+	if recencyThreshold == 0 {
+		recencyThreshold = time.Second * 20 // this default is based on a block time of 15 seconds
+	}
+	// double the block time and add half block time drift to allow headersub
+	// some time to deliver a more recent head before eagerly requesting a new
+	// head
+	return time.Since(header.Time()) <= recencyThreshold
 }

--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -189,13 +189,10 @@ func isExpired[H header.Header[H]](header H, period time.Duration) bool {
 	return !expirationTime.After(time.Now())
 }
 
-// isRecent checks if header is recent against the given blockTime.
+// isRecent checks if header is recent against the given recency threshold.
 func isRecent[H header.Header[H]](header H, recencyThreshold time.Duration) bool {
 	if recencyThreshold == 0 {
 		recencyThreshold = time.Second * 20 // this default is based on a block time of 15 seconds
 	}
-	// double the block time and add half block time drift to allow headersub
-	// some time to deliver a more recent head before eagerly requesting a new
-	// head
 	return time.Since(header.Time()) <= recencyThreshold
 }

--- a/sync/sync_head_test.go
+++ b/sync/sync_head_test.go
@@ -75,8 +75,8 @@ func TestSyncer_HeadWithTrustedHead(t *testing.T) {
 		wrappedGetter,
 		localStore,
 		headertest.NewDummySubscriber(),
-		// forces a request for a new sync target
 		WithBlockTime(time.Nanosecond),
+		WithRecencyThreshold(time.Nanosecond), // forces a request for a new sync target
 		// ensures that syncer's store contains a subjective head that is within
 		// the unbonding period so that the syncer can use a header from the network
 		// as a sync target

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -34,6 +34,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 		localStore,
 		headertest.NewDummySubscriber(),
 		WithBlockTime(time.Second*30),
+		WithRecencyThreshold(time.Second*35), // add 5 second buffer
 		WithTrustingPeriod(time.Microsecond),
 	)
 	require.NoError(t, err)
@@ -72,6 +73,8 @@ func TestDoSyncFullRangeFromExternalPeer(t *testing.T) {
 		local.NewExchange(remoteStore),
 		localStore,
 		headertest.NewDummySubscriber(),
+		WithBlockTime(time.Nanosecond),
+		WithRecencyThreshold(time.Nanosecond),
 	)
 	require.NoError(t, err)
 	require.NoError(t, syncer.Start(ctx))
@@ -306,7 +309,8 @@ func TestSync_InvalidSyncTarget(t *testing.T) {
 		local.NewExchange[*headertest.DummyHeader](remoteStore),
 		localStore,
 		headertest.NewDummySubscriber(),
-		WithBlockTime(time.Nanosecond), // force syncer to request more recent sync target
+		WithBlockTime(time.Nanosecond),
+		WithRecencyThreshold(time.Nanosecond), // force syncer to request more recent sync target
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Doubles the blocktime + some drift to allow a bit more slack for recency determination. The aim here is to increase the threshold for requesting head over Exchange if it isn't completely necessary.

resolves #98 