### PR TITLE
fix!: remove lifecycle methods from the interface

### DIFF
--- a/headertest/store.go
+++ b/headertest/store.go
@@ -41,8 +41,6 @@ func NewStore[H header.Header[H]](t *testing.T, gen Generator[H], numHeaders int
 }
 
 func (m *Store[H]) Init(context.Context, H) error { return nil }
-func (m *Store[H]) Start(context.Context) error   { return nil }
-func (m *Store[H]) Stop(context.Context) error    { return nil }
 
 func (m *Store[H]) Height() uint64 {
 	return uint64(m.HeadHeight)

--- a/interface.go
+++ b/interface.go
@@ -72,13 +72,6 @@ func (ena *ErrNonAdjacent) Error() string {
 // Store encompasses the behavior necessary to store and retrieve Headers
 // from a node's local storage.
 type Store[H Header[H]] interface {
-	// Start starts the store.
-	Start(context.Context) error
-
-	// Stop stops the store by preventing further writes
-	// and waiting till the ongoing ones are done.
-	Stop(context.Context) error
-
 	// Getter encompasses all getter methods for headers.
 	Getter[H]
 


### PR DESCRIPTION
It's net negative to enforce life cycling methods on the interface.

Closes #6 