### PR TITLE
chore(sync): update default trusting period to 2 weeks instead of 1

### DIFF
--- a/sync/options.go
+++ b/sync/options.go
@@ -34,7 +34,7 @@ type Parameters struct {
 // DefaultParameters returns the default params to configure the syncer.
 func DefaultParameters() Parameters {
 	return Parameters{
-		TrustingPeriod: 168 * time.Hour,
+		TrustingPeriod: 336 * time.Hour,
 	}
 }
 


### PR DESCRIPTION
Changing the default to 2 weeks instead of 1