### PR TITLE
fix(p2p/exchange): Remove peer blocking from head request

### DIFF
--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -163,8 +163,6 @@ func (ex *Exchange[H]) Head(ctx context.Context, opts ...header.HeadOption[H]) (
 						headerRespCh <- headers[0]
 						return
 					}
-					// bad head was given, block peer
-					ex.peerTracker.blockPeer(from, fmt.Errorf("returned bad head: %w", err))
 					log.Errorw("verifying head received from tracked peer", "tracked peer", from,
 						"height", headers[0].Height(), "err", err)
 					headerRespCh <- zero


### PR DESCRIPTION
Currently, the exchange will block peers for giving a bad header that does not pass the `Verify` check (unless it is a `SoftFailure`). Unless we introduce another field inside of `VerifyError` to indicate to the caller whether the error was severe enough to warrant blocking, we shouldn't blanket block for verify errors as a good peer that sends a slightly outdated header will get banned. 

(this is currently observable on `arabica` - have not tested on mocha yet)

**Moral of the story: do not prematurely implement blocking behaviour.**