### PR TITLE
fix(sync): allow a greater buffer for recency threshold default

### DIFF
--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -192,7 +192,7 @@ func isExpired[H header.Header[H]](header H, period time.Duration) bool {
 // isRecent checks if header is recent against the given recency threshold.
 func isRecent[H header.Header[H]](header H, blockTime, recencyThreshold time.Duration) bool {
 	if recencyThreshold == 0 {
-		recencyThreshold = blockTime + blockTime/2 // allow some drift by adding additional buffer of 1/2 of block time
+		recencyThreshold = blockTime * 2 // allow some drift by adding additional buffer of 2 blocks
 	}
 	return time.Since(header.Time()) <= recencyThreshold
 }


### PR DESCRIPTION
While this is a quick fix to prevent the syncer from doing additional unnecessary work (eagerly requesting a new Head from the network), the proper solution here would be to implement metrics to gain better insight into average block time of the network **and** to allow the `recencyThreshold` to be determined based on an average time of the last n amount of blocks.