### PR TITLE
refactor!: Merge `GetVerifiedRange` and `GetRangeByHeight` in Getter interface and remove redundant endpoint

### DIFF
--- a/headertest/store.go
+++ b/headertest/store.go
@@ -64,8 +64,20 @@ func (m *Store[H]) GetByHeight(ctx context.Context, height uint64) (H, error) {
 	return m.Headers[height], nil
 }
 
-func (m *Store[H]) GetRangeByHeight(ctx context.Context, from, to uint64) ([]H, error) {
-	headers := make([]H, to-from)
+func (m *Store[H]) GetRange(ctx context.Context, from, to uint64) ([]H, error) {
+	return m.getRangeByHeight(ctx, from, to)
+}
+
+// GetRangeByHeight returns headers in range [from; to).
+func (m *Store[H]) GetRangeByHeight(ctx context.Context, fromHead H, to uint64) ([]H, error) {
+	from := fromHead.Height() + 1
+	return m.getRangeByHeight(ctx, from, to)
+}
+
+func (m *Store[H]) getRangeByHeight(ctx context.Context, from, to uint64) ([]H, error) {
+	amount := to - from
+	headers := make([]H, amount)
+
 	// As the requested range is [from; to),
 	// check that (to-1) height in request is less than
 	// the biggest header height in store.
@@ -77,14 +89,6 @@ func (m *Store[H]) GetRangeByHeight(ctx context.Context, from, to uint64) ([]H, 
 		from++
 	}
 	return headers, nil
-}
-
-func (m *Store[H]) GetVerifiedRange(
-	ctx context.Context,
-	h H,
-	to uint64,
-) ([]H, error) {
-	return m.GetRangeByHeight(ctx, uint64(h.Height())+1, to)
 }
 
 func (m *Store[H]) Has(context.Context, header.Hash) (bool, error) {

--- a/interface.go
+++ b/interface.go
@@ -111,6 +111,7 @@ type Getter[H Header[H]] interface {
 
 	// GetRangeByHeight requests the header range from the provided Header and
 	// verifies that the returned headers are adjacent to each other.
+	// Expected to return the range [from.Height()+1:to).
 	GetRangeByHeight(ctx context.Context, from H, to uint64) ([]H, error)
 }
 

--- a/interface.go
+++ b/interface.go
@@ -93,6 +93,9 @@ type Store[H Header[H]] interface {
 	// It returns the amount of successfully applied headers,
 	// so caller can understand what given header was invalid, if any.
 	Append(context.Context, ...H) error
+
+	// GetRange returns the range [from:to).
+	GetRange(context.Context, uint64, uint64) ([]H, error)
 }
 
 // Getter contains the behavior necessary for a component to retrieve
@@ -106,12 +109,9 @@ type Getter[H Header[H]] interface {
 	// GetByHeight returns the Header corresponding to the given block height.
 	GetByHeight(context.Context, uint64) (H, error)
 
-	// GetRangeByHeight returns the given range of Headers.
-	GetRangeByHeight(ctx context.Context, from, amount uint64) ([]H, error)
-
-	// GetVerifiedRange requests the header range from the provided Header and
+	// GetRangeByHeight requests the header range from the provided Header and
 	// verifies that the returned headers are adjacent to each other.
-	GetVerifiedRange(ctx context.Context, from H, amount uint64) ([]H, error)
+	GetRangeByHeight(ctx context.Context, from H, to uint64) ([]H, error)
 }
 
 // Head contains the behavior necessary for a component to retrieve

--- a/local/exchange.go
+++ b/local/exchange.go
@@ -34,16 +34,9 @@ func (l *Exchange[H]) GetByHeight(ctx context.Context, height uint64) (H, error)
 	return l.store.GetByHeight(ctx, height)
 }
 
-func (l *Exchange[H]) GetRangeByHeight(ctx context.Context, origin, amount uint64) ([]H, error) {
-	if amount == 0 {
-		return nil, nil
-	}
-	return l.store.GetRangeByHeight(ctx, origin, origin+amount)
-}
-
-func (l *Exchange[H]) GetVerifiedRange(ctx context.Context, from H, amount uint64,
+func (l *Exchange[H]) GetRangeByHeight(ctx context.Context, from H, to uint64,
 ) ([]H, error) {
-	return l.store.GetVerifiedRange(ctx, from, uint64(from.Height())+amount+1)
+	return l.store.GetRangeByHeight(ctx, from, to)
 }
 
 func (l *Exchange[H]) Get(ctx context.Context, hash header.Hash) (H, error) {

--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -213,36 +213,20 @@ func (ex *Exchange[H]) GetByHeight(ctx context.Context, height uint64) (H, error
 	return headers[0], nil
 }
 
-// GetRangeByHeight performs a request for the given range of Headers
-// to the network. Note that the Headers must be verified thereafter.
-func (ex *Exchange[H]) GetRangeByHeight(ctx context.Context, from, amount uint64) ([]H, error) {
-	if amount == 0 {
-		return make([]H, 0), nil
-	}
-	if amount > header.MaxRangeRequestSize {
-		return nil, header.ErrHeadersLimitExceeded
-	}
-	session := newSession[H](ex.ctx, ex.host, ex.peerTracker, ex.protocolID, ex.Params.RangeRequestTimeout)
-	defer session.close()
-	return session.getRangeByHeight(ctx, from, amount, ex.Params.MaxHeadersPerRangeRequest)
-}
-
-// GetVerifiedRange performs a request for the given range of Headers to the network and
+// GetRangeByHeight performs a request for the given range of Headers to the network and
 // ensures that returned headers are correct against the passed one.
-func (ex *Exchange[H]) GetVerifiedRange(
+func (ex *Exchange[H]) GetRangeByHeight(
 	ctx context.Context,
 	from H,
-	amount uint64,
+	to uint64,
 ) ([]H, error) {
-	if amount == 0 {
-		return make([]H, 0), nil
-	}
 	session := newSession[H](
 		ex.ctx, ex.host, ex.peerTracker, ex.protocolID, ex.Params.RangeRequestTimeout, withValidation(from),
 	)
 	defer session.close()
 	// we request the next header height that we don't have: `fromHead`+1
-	return session.getRangeByHeight(ctx, uint64(from.Height())+1, amount, ex.Params.MaxHeadersPerRangeRequest)
+	amount := to - (from.Height() + 1)
+	return session.getRangeByHeight(ctx, from.Height()+1, amount, ex.Params.MaxHeadersPerRangeRequest)
 }
 
 // Get performs a request for the Header by the given hash corresponding

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -210,7 +210,7 @@ func (serv *ExchangeServer[H]) handleRequest(from, to uint64) ([]H, error) {
 		}
 
 		// might be a case when store hasn't synced yet to the requested range
-		if uint64(head.Height()) < from {
+		if head.Height() < from {
 			span.SetStatus(codes.Error, header.ErrNotFound.Error())
 			log.Debugw("server: requested headers not stored",
 				"from", from,
@@ -229,7 +229,7 @@ func (serv *ExchangeServer[H]) handleRequest(from, to uint64) ([]H, error) {
 		to = uint64(head.Height()) + 1
 	}
 
-	headersByRange, err := serv.store.GetRangeByHeight(ctx, from, to)
+	headersByRange, err := serv.store.GetRange(ctx, from, to)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		if errors.Is(err, context.DeadlineExceeded) {

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	"github.com/stretchr/testify/require"
 
+	"github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/go-header/headertest"
 	"github.com/celestiaorg/go-header/store"
 )
@@ -28,5 +29,25 @@ func TestExchangeServer_handleRequestTimeout(t *testing.T) {
 	})
 
 	_, err = server.handleRequest(1, 200)
+	require.Error(t, err)
+}
+
+func TestExchangeServer_errorsOnLargeRequest(t *testing.T) {
+	peer := createMocknet(t, 1)
+	s, err := store.NewStore[*headertest.DummyHeader](datastore.NewMapDatastore())
+	require.NoError(t, err)
+	server, err := NewExchangeServer[*headertest.DummyHeader](
+		peer[0],
+		s,
+		WithNetworkID[ServerParameters](networkID),
+	)
+	require.NoError(t, err)
+	err = server.Start(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		server.Stop(context.Background()) //nolint:errcheck
+	})
+
+	_, err = server.handleRequest(1, header.MaxRangeRequestSize*2)
 	require.Error(t, err)
 }

--- a/p2p/session.go
+++ b/p2p/session.go
@@ -197,7 +197,7 @@ func (s *session[H]) doRequest(
 	responseLn := uint64(len(h))
 	// ensure that we received the correct amount of headers.
 	if responseLn < req.Amount {
-		from := uint64(h[responseLn-1].Height())
+		from := h[responseLn-1].Height()
 		amount := req.Amount - responseLn
 
 		select {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -34,7 +34,7 @@ func TestStore(t *testing.T) {
 	err = store.Append(ctx, in...)
 	require.NoError(t, err)
 
-	out, err := store.getRangeByHeight(ctx, 2, 12)
+	out, err := store.GetRange(ctx, 2, 12)
 	require.NoError(t, err)
 	for i, h := range in {
 		assert.Equal(t, h.Hash(), out[i].Hash())
@@ -75,7 +75,7 @@ func TestStore(t *testing.T) {
 	assert.NotNil(t, out)
 	assert.Len(t, out, 1)
 
-	out, err = store.getRangeByHeight(ctx, 2, 2)
+	out, err = store.GetRange(ctx, 2, 2)
 	require.Error(t, err)
 	assert.Nil(t, out)
 
@@ -237,10 +237,10 @@ func TestStorePendingCacheMiss(t *testing.T) {
 	err = store.Append(ctx, suite.GenDummyHeaders(50)...)
 	require.NoError(t, err)
 
-	_, err = store.getRangeByHeight(ctx, 1, 101)
+	_, err = store.GetRange(ctx, 1, 101)
 	require.NoError(t, err)
 
-	_, err = store.getRangeByHeight(ctx, 101, 151)
+	_, err = store.GetRange(ctx, 101, 151)
 	require.NoError(t, err)
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -99,8 +99,8 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 }
 
-//TestStoreGetByHeight_ExpectedRange
-func TestStoreGetByHeight_ExpectedRange(t *testing.T) {
+// TestStore_GetRangeByHeight_ExpectedRange
+func TestStore_GetRangeByHeight_ExpectedRange(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)
 
@@ -121,7 +121,7 @@ func TestStoreGetByHeight_ExpectedRange(t *testing.T) {
 	err = store.Append(ctx, in...)
 	require.NoError(t, err)
 
-	// request the range [4:98) || (from:to)
+	// request the range [4:98] || (from:to)
 	from := in[2]
 	firstHeaderInRangeHeight := from.Height() + 1
 	lastHeaderInRangeHeight := uint64(98)
@@ -129,6 +129,42 @@ func TestStoreGetByHeight_ExpectedRange(t *testing.T) {
 	expectedLenHeaders := to - firstHeaderInRangeHeight // expected amount
 
 	out, err := store.GetRangeByHeight(ctx, from, to)
+	require.NoError(t, err)
+
+	assert.Len(t, out, int(expectedLenHeaders))
+	assert.Equal(t, firstHeaderInRangeHeight, out[0].Height())
+	assert.Equal(t, lastHeaderInRangeHeight, out[len(out)-1].Height())
+}
+
+// TestStore_GetRange_ExpectedRange
+func TestStore_GetRange_ExpectedRange(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	store, err := NewStoreWithHead(ctx, ds, suite.Head())
+	require.NoError(t, err)
+
+	err = store.Start(ctx)
+	require.NoError(t, err)
+
+	head, err := store.Head(ctx)
+	require.NoError(t, err)
+	assert.EqualValues(t, suite.Head().Hash(), head.Hash())
+
+	in := suite.GenDummyHeaders(100)
+	err = store.Append(ctx, in...)
+	require.NoError(t, err)
+
+	// request the range [4:98]
+	firstHeaderInRangeHeight := uint64(4)
+	lastHeaderInRangeHeight := uint64(98)
+	to := lastHeaderInRangeHeight + 1
+	expectedLenHeaders := to - firstHeaderInRangeHeight // expected amount
+
+	out, err := store.GetRange(ctx, firstHeaderInRangeHeight, to)
 	require.NoError(t, err)
 
 	assert.Len(t, out, int(expectedLenHeaders))

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -34,7 +34,7 @@ func TestStore(t *testing.T) {
 	err = store.Append(ctx, in...)
 	require.NoError(t, err)
 
-	out, err := store.GetRangeByHeight(ctx, 2, 12)
+	out, err := store.getRangeByHeight(ctx, 2, 12)
 	require.NoError(t, err)
 	for i, h := range in {
 		assert.Equal(t, h.Hash(), out[i].Hash())
@@ -66,16 +66,16 @@ func TestStore(t *testing.T) {
 
 	h, err = store.GetByHeight(ctx, 2)
 	require.NoError(t, err)
-	out, err = store.GetVerifiedRange(ctx, h, 3)
+	out, err = store.GetRangeByHeight(ctx, h, 3)
 	require.Error(t, err)
 	assert.Nil(t, out)
 
-	out, err = store.GetVerifiedRange(ctx, h, 4)
+	out, err = store.GetRangeByHeight(ctx, h, 4)
 	require.NoError(t, err)
 	assert.NotNil(t, out)
 	assert.Len(t, out, 1)
 
-	out, err = store.GetRangeByHeight(ctx, 2, 2)
+	out, err = store.getRangeByHeight(ctx, 2, 2)
 	require.Error(t, err)
 	assert.Nil(t, out)
 
@@ -91,7 +91,7 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, suite.Head().Hash(), head.Hash())
 
-	out, err = store.GetRangeByHeight(ctx, 1, 13)
+	out, err = store.getRangeByHeight(ctx, 1, 13)
 	require.NoError(t, err)
 	assert.Len(t, out, 12)
 
@@ -121,10 +121,10 @@ func TestStorePendingCacheMiss(t *testing.T) {
 	err = store.Append(ctx, suite.GenDummyHeaders(50)...)
 	require.NoError(t, err)
 
-	_, err = store.GetRangeByHeight(ctx, 1, 101)
+	_, err = store.getRangeByHeight(ctx, 1, 101)
 	require.NoError(t, err)
 
-	_, err = store.GetRangeByHeight(ctx, 101, 151)
+	_, err = store.getRangeByHeight(ctx, 101, 151)
 	require.NoError(t, err)
 }
 

--- a/sync/sync_getter_test.go
+++ b/sync/sync_getter_test.go
@@ -67,10 +67,6 @@ func (f *fakeGetter[H]) GetByHeight(ctx context.Context, u uint64) (H, error) {
 	panic("implement me")
 }
 
-func (f *fakeGetter[H]) GetRangeByHeight(ctx context.Context, from, amount uint64) ([]H, error) {
-	panic("implement me")
-}
-
-func (f *fakeGetter[H]) GetVerifiedRange(ctx context.Context, from H, amount uint64) ([]H, error) {
+func (f *fakeGetter[H]) GetRangeByHeight(ctx context.Context, from H, amount uint64) ([]H, error) {
 	panic("implement me")
 }

--- a/sync/sync_getter_test.go
+++ b/sync/sync_getter_test.go
@@ -67,6 +67,6 @@ func (f *fakeGetter[H]) GetByHeight(ctx context.Context, u uint64) (H, error) {
 	panic("implement me")
 }
 
-func (f *fakeGetter[H]) GetRangeByHeight(ctx context.Context, from H, amount uint64) ([]H, error) {
+func (f *fakeGetter[H]) GetRangeByHeight(ctx context.Context, from H, to uint64) ([]H, error) {
 	panic("implement me")
 }

--- a/sync/sync_head_test.go
+++ b/sync/sync_head_test.go
@@ -138,7 +138,7 @@ func (t *wrappedGetter) GetByHeight(ctx context.Context, u uint64) (*headertest.
 func (t *wrappedGetter) GetRangeByHeight(
 	ctx context.Context,
 	from *headertest.DummyHeader,
-	amount uint64,
+	to uint64,
 ) ([]*headertest.DummyHeader, error) {
 	//TODO implement me
 	panic("implement me")

--- a/sync/sync_head_test.go
+++ b/sync/sync_head_test.go
@@ -135,12 +135,11 @@ func (t *wrappedGetter) GetByHeight(ctx context.Context, u uint64) (*headertest.
 	panic("implement me")
 }
 
-func (t *wrappedGetter) GetRangeByHeight(ctx context.Context, from, amount uint64) ([]*headertest.DummyHeader, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (t *wrappedGetter) GetVerifiedRange(ctx context.Context, from *headertest.DummyHeader, amount uint64) ([]*headertest.DummyHeader, error) {
+func (t *wrappedGetter) GetRangeByHeight(
+	ctx context.Context,
+	from *headertest.DummyHeader,
+	amount uint64,
+) ([]*headertest.DummyHeader, error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -388,10 +388,10 @@ type delayedGetter[H header.Header[H]] struct {
 	header.Getter[H]
 }
 
-func (d *delayedGetter[H]) GetRangeByHeight(ctx context.Context, from H, amount uint64) ([]H, error) {
+func (d *delayedGetter[H]) GetRangeByHeight(ctx context.Context, from H, to uint64) ([]H, error) {
 	select {
 	case <-time.After(time.Millisecond * 100):
-		return d.Getter.GetRangeByHeight(ctx, from, amount)
+		return d.Getter.GetRangeByHeight(ctx, from, to)
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -388,10 +388,10 @@ type delayedGetter[H header.Header[H]] struct {
 	header.Getter[H]
 }
 
-func (d *delayedGetter[H]) GetVerifiedRange(ctx context.Context, from H, amount uint64) ([]H, error) {
+func (d *delayedGetter[H]) GetRangeByHeight(ctx context.Context, from H, amount uint64) ([]H, error) {
 	select {
 	case <-time.After(time.Millisecond * 100):
-		return d.Getter.GetVerifiedRange(ctx, from, amount)
+		return d.Getter.GetRangeByHeight(ctx, from, amount)
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}


### PR DESCRIPTION
Merges `GetVerifiedRange` functionality into `GetRangeByHeight` (breaks `GetRangeByHeight` signature and removes `GetVerifiedRange`)

No need for two methods doing the same thing.

Also introduces `GetRange` on `store.Store` interface to allow requesting local headers without passing in a `fromHead` for verification - this prevents p2p server from needing to perform an additional read (to get the `fromHead`) from the store to perform the `GetRangeByHeight` request.