### PR TITLE
fix!: handle error on metrics

### DIFF
--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -65,7 +65,11 @@ func NewExchange[H header.Header[H]](
 
 	var metrics *metrics
 	if params.metrics {
-		metrics = newExchangeMetrics()
+		var err error
+		metrics, err = newExchangeMetrics()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	ex := &Exchange[H]{

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -15,25 +15,25 @@ type metrics struct {
 	responseDuration metric.Float64Histogram
 }
 
-func newExchangeMetrics() *metrics {
+func newExchangeMetrics() (*metrics, error) {
 	responseSize, err := meter.Float64Histogram(
 		"header_p2p_exchange_response_size",
 		metric.WithDescription("Size of get headers response in bytes"),
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	responseDuration, err := meter.Float64Histogram(
 		"header_p2p_exchange_request_duration",
 		metric.WithDescription("Duration of get headers request in seconds"),
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	return &metrics{
 		responseSize:     responseSize,
 		responseDuration: responseDuration,
-	}
+	}, nil
 }
 
 func (m *metrics) observeResponse(ctx context.Context, size uint64, duration uint64, err error) {

--- a/p2p/subscriber.go
+++ b/p2p/subscriber.go
@@ -51,7 +51,7 @@ func NewSubscriber[H header.Header[H]](
 	ps *pubsub.PubSub,
 	msgID pubsub.MsgIdFunction,
 	opts ...SubscriberOption,
-) *Subscriber[H] {
+) (*Subscriber[H], error) {
 	var params SubscriberParams
 	for _, opt := range opts {
 		opt(&params)
@@ -61,7 +61,7 @@ func NewSubscriber[H header.Header[H]](
 		pubsubTopicID: PubsubTopicID(params.networkID),
 		pubsub:        ps,
 		msgID:         msgID,
-	}
+	}, nil
 }
 
 // Start starts the Subscriber, registering a topic validator for the "header-sub"

--- a/p2p/subscription_test.go
+++ b/p2p/subscription_test.go
@@ -30,7 +30,8 @@ func TestSubscriber(t *testing.T) {
 	require.NoError(t, err)
 
 	// create sub-service lifecycles for header service 1
-	p2pSub1 := NewSubscriber[*headertest.DummyHeader](pubsub1, pubsub.DefaultMsgIdFn, WithSubscriberNetworkID(networkID))
+	p2pSub1, err := NewSubscriber[*headertest.DummyHeader](pubsub1, pubsub.DefaultMsgIdFn, WithSubscriberNetworkID(networkID))
+	require.NoError(t, err)
 	err = p2pSub1.Start(context.Background())
 	require.NoError(t, err)
 
@@ -40,7 +41,8 @@ func TestSubscriber(t *testing.T) {
 	require.NoError(t, err)
 
 	// create sub-service lifecycles for header service 2
-	p2pSub2 := NewSubscriber[*headertest.DummyHeader](pubsub2, pubsub.DefaultMsgIdFn, WithSubscriberNetworkID(networkID))
+	p2pSub2, err := NewSubscriber[*headertest.DummyHeader](pubsub2, pubsub.DefaultMsgIdFn, WithSubscriberNetworkID(networkID))
+	require.NoError(t, err)
 	err = p2pSub2.Start(context.Background())
 	require.NoError(t, err)
 

--- a/sync/metrics.go
+++ b/sync/metrics.go
@@ -15,13 +15,13 @@ type metrics struct {
 	totalSyncedGauge metric.Float64ObservableGauge
 }
 
-func newMetrics() *metrics {
+func newMetrics() (*metrics, error) {
 	totalSynced, err := meter.Float64ObservableGauge(
 		"total_synced_headers",
 		metric.WithDescription("total synced headers"),
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	m := &metrics{
@@ -34,10 +34,10 @@ func newMetrics() *metrics {
 	}
 	_, err = meter.RegisterCallback(callback, totalSynced)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return m
+	return m, nil
 }
 
 // recordTotalSynced records the total amount of synced headers.

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -71,7 +71,11 @@ func NewSyncer[H header.Header[H]](
 
 	var metrics *metrics
 	if params.metrics {
-		metrics = newMetrics()
+		var err error
+		metrics, err = newMetrics()
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &Syncer[H]{
 		sub:         sub,


### PR DESCRIPTION
I treated metrics initialization as like it's being run in `init` while it's not. Even if these are programmer bug errors, metrics initialization will happen after some other components have started, causing various artifacts if not stopped gracefully.