### PR TITLE
fix(sync): Fix `total_synced` metric recording

### DIFF
--- a/sync/metrics.go
+++ b/sync/metrics.go
@@ -46,5 +46,5 @@ func (m *metrics) recordTotalSynced(totalSynced int) {
 		return
 	}
 
-	m.totalSynced.Store(int64(totalSynced))
+	m.totalSynced.Add(int64(totalSynced))
 }


### PR DESCRIPTION
Fixes the `total_synced` metric such that it actually updates the total amount of synced headers rather than overriding the value every time (missed this during code review of #121)