### PR TITLE
feat(sync): networkHead callback metric

### DIFF
--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -121,11 +121,14 @@ func (s *Syncer[H]) setSubjectiveHead(ctx context.Context, netHead H) {
 			"err", err)
 	}
 
+	defer s.metrics.recordNetworkHead(netHead.Height())
+
 	storeHead, err := s.store.Head(ctx)
 	if err == nil && storeHead.Height() >= netHead.Height() {
 		// we already synced it up - do nothing
 		return
 	}
+
 	// and if valid, set it as new subjective head
 	s.pending.Add(netHead)
 	s.wantSync()


### PR DESCRIPTION
As per request

https://github.com/celestiaorg/celestia-node/issues/2921#issuecomment-1808209246

While this isn't super high priority - it is true that `totalSynced` metric does not correlate to what the current networkHead is. There is no way currently to determine what the netHead of the node is via metric (local head does not suffice as it's only reporting store head).

