### PR TITLE
feat(peer-tracker): add minAmount of peers tracked in tracker

### DIFF
--- a/p2p/peer_tracker.go
+++ b/p2p/peer_tracker.go
@@ -18,7 +18,7 @@ const (
 	defaultScore float32 = 1
 	// maxPeerTrackerSize specifies the max amount of peers that can be added to the peerTracker.
 	maxPeerTrackerSize = 100
-	// minPeerTrackerSizeBeforeGC specifies the min amount of peers before the peerTracker starts removing peers.
+	// minPeerTrackerSizeBeforeGC specifies the minimum amount of tracked peers before the peerTracker starts removing peers with lower peer scores.
 	minPeerTrackerSizeBeforeGC = 10
 )
 


### PR DESCRIPTION
Adds `minPeerTrackerSizeBeforeGC` setting to peer tracker, that specifies the min amount of peers before the peerTracker starts removing peers.