### PR TITLE
fix(p2p): fix metrics in p2p package

### DIFF
--- a/p2p/exchange_metrics.go
+++ b/p2p/exchange_metrics.go
@@ -99,10 +99,10 @@ func newExchangeMetrics() (m *exchangeMetrics, err error) {
 	return m, nil
 }
 
-func (m *exchangeMetrics) observeMetrics(ctx context.Context, obs metric.Observer) error {
-	_ = m.observeTrackedPeers(ctx, obs)
-	_ = m.observeDisconnectedPeers(ctx, obs)
-	_ = m.observeBlockedPeers(ctx, obs)
+func (m *exchangeMetrics) observeMetrics(_ context.Context, obs metric.Observer) error {
+	obs.ObserveInt64(m.trackedPeersNumInst, m.trackerPeersNum.Load())
+	obs.ObserveInt64(m.disconnectedPeersNumInst, m.disconnectedPeersNum.Load())
+	obs.ObserveInt64(m.blockedPeersNumInst, m.blockedPeersNum.Load())
 	return nil
 }
 
@@ -148,21 +148,6 @@ func (m *exchangeMetrics) peerBlocked() {
 	m.observe(context.Background(), func(ctx context.Context) {
 		m.blockedPeersNum.Add(1)
 	})
-}
-
-func (m *exchangeMetrics) observeTrackedPeers(_ context.Context, obs metric.Observer) error {
-	obs.ObserveInt64(m.trackedPeersNumInst, m.trackerPeersNum.Load())
-	return nil
-}
-
-func (m *exchangeMetrics) observeDisconnectedPeers(_ context.Context, obs metric.Observer) error {
-	obs.ObserveInt64(m.disconnectedPeersNumInst, m.disconnectedPeersNum.Load())
-	return nil
-}
-
-func (m *exchangeMetrics) observeBlockedPeers(_ context.Context, obs metric.Observer) error {
-	obs.ObserveInt64(m.blockedPeersNumInst, m.blockedPeersNum.Load())
-	return nil
 }
 
 func (m *exchangeMetrics) observe(ctx context.Context, observeFn func(context.Context)) {

--- a/p2p/exchange_metrics.go
+++ b/p2p/exchange_metrics.go
@@ -30,8 +30,6 @@ type exchangeMetrics struct {
 	responseSizeInst    metric.Int64Histogram
 	responseTimeInst    metric.Float64Histogram
 
-	clientReg metric.Registration
-
 	trackerPeersNum     atomic.Int64
 	trackedPeersNumInst metric.Int64ObservableGauge
 
@@ -40,6 +38,8 @@ type exchangeMetrics struct {
 
 	blockedPeersNum     atomic.Int64
 	blockedPeersNumInst metric.Int64ObservableGauge
+
+	clientReg metric.Registration
 }
 
 func newExchangeMetrics() (m *exchangeMetrics, err error) {

--- a/p2p/subscriber_metrics.go
+++ b/p2p/subscriber_metrics.go
@@ -5,9 +5,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
+
+var subsMeter = otel.Meter("header/p2p-subs/")
 
 const (
 	statusKey    = "status"
@@ -30,35 +33,35 @@ type subscriberMetrics struct {
 
 func newSubscriberMetrics() (m *subscriberMetrics, err error) {
 	m = new(subscriberMetrics)
-	m.messageNumInst, err = meter.Int64Counter(
+	m.messageNumInst, err = subsMeter.Int64Counter(
 		"hdr_p2p_sub_msg_num_counter",
 		metric.WithDescription("header message count"),
 	)
 	if err != nil {
 		return nil, err
 	}
-	m.messageSizeInst, err = meter.Int64Histogram(
+	m.messageSizeInst, err = subsMeter.Int64Histogram(
 		"hdr_p2p_sub_msg_size_hist",
 		metric.WithDescription("valid header message size"),
 	)
 	if err != nil {
 		return nil, err
 	}
-	m.messageTimeInst, err = meter.Float64Histogram(
+	m.messageTimeInst, err = subsMeter.Float64Histogram(
 		"hdr_p2p_sub_msg_time_hist",
 		metric.WithDescription("valid header message propagation time"),
 	)
 	if err != nil {
 		return nil, err
 	}
-	m.subscriptionNumInst, err = meter.Int64ObservableGauge(
+	m.subscriptionNumInst, err = subsMeter.Int64ObservableGauge(
 		"hdr_p2p_sub_num_gauge",
 		metric.WithDescription("number of active header message subscriptions"),
 	)
 	if err != nil {
 		return nil, err
 	}
-	m.subscriptionNumReg, err = meter.RegisterCallback(m.subscriptionCallback, m.subscriptionNumInst)
+	m.subscriptionNumReg, err = subsMeter.RegisterCallback(m.subscriptionCallback, m.subscriptionNumInst)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Previously some metrics did not work in the p2p package because Otel does not allow registering multiple callbacks per `otel.Meter` instance. At some point tracked/disconnected/blocked metrics were overwritten by subscription metric callback. Added single `metric.Registration` in exchange client and created a separate instance for subscriber metrics.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
