### PR TITLE
fix(syncer): set timeout for head request

### DIFF
--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -38,10 +38,10 @@ func (s *Syncer[H]) Head(ctx context.Context, _ ...header.HeadOption[H]) (H, err
 		return s.Head(ctx)
 	}
 	defer s.getter.Unlock()
-
-	reqCtx, cancel := context.WithTimeout(ctx, time.Second*2)
+	// limit time to get a recent header
+	// if can't get it - give what we have
+	reqCtx, cancel := context.WithTimeout(ctx, time.Second*2) // TODO(@vgonkivs): make timeout configurable
 	defer cancel()
-
 	netHead, err := s.getter.Head(reqCtx, header.WithTrustedHead[H](sbjHead))
 	if err != nil {
 		log.Warnw("failed to get recent head, returning current subjective", "sbjHead", sbjHead.Height(), "err", err)

--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -25,12 +25,7 @@ func (s *Syncer[H]) Head(ctx context.Context, _ ...header.HeadOption[H]) (H, err
 		return sbjHead, nil
 	}
 	// otherwise, request head from the network
-	//
-	// TODO(@Wondertan): Here is another potential networking optimization:
-	//  * From sbjHead's timestamp and current time predict the time to the next header(TNH)
-	//  * If now >= TNH && now <= TNH + (THP) header propagation time
-	//    * Wait for header to arrive instead of requesting it
-	//  * This way we don't request as we know the new network header arrives exactly
+	// TODO: Besides requesting we should listen for new gossiped headers and cancel request if so
 	//
 	// single-flight protection
 	// ensure only one Head is requested at the time

--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -38,7 +38,11 @@ func (s *Syncer[H]) Head(ctx context.Context, _ ...header.HeadOption[H]) (H, err
 		return s.Head(ctx)
 	}
 	defer s.getter.Unlock()
-	netHead, err := s.getter.Head(ctx, header.WithTrustedHead[H](sbjHead))
+
+	reqCtx, cancel := context.WithTimeout(ctx, time.Second*2)
+	defer cancel()
+
+	netHead, err := s.getter.Head(reqCtx, header.WithTrustedHead[H](sbjHead))
 	if err != nil {
 		log.Warnw("failed to get recent head, returning current subjective", "sbjHead", sbjHead.Height(), "err", err)
 		return s.subjectiveHead(ctx)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Set timeout to avoid the syncer being stuck on the Head request if the other node is unresponsive.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
