### PR TITLE
fix(p2p/session): return peer to the queue in case of ErrNotFound

### DIFF
--- a/p2p/peer_tracker_test.go
+++ b/p2p/peer_tracker_test.go
@@ -33,22 +33,17 @@ func TestPeerTracker_GC(t *testing.T) {
 
 	maxAwaitingTime = time.Millisecond
 
-	peerlist := generateRandomPeerlist(t, minPeerTrackerSizeBeforeGC)
-	for i := 0; i < minPeerTrackerSizeBeforeGC; i++ {
+	peerlist := generateRandomPeerlist(t, 10)
+	for i := 0; i < 10; i++ {
 		p.trackedPeers[peerlist[i]] = &peerStat{peerID: peerlist[i], peerScore: 0.5}
 	}
 
-	// add peers to trackedPeers to make total number of peers > maxPeerTrackerSize
 	peerlist = generateRandomPeerlist(t, 4)
-	pid1 := peerlist[0]
-	pid2 := peerlist[1]
-	pid3 := peerlist[2]
-	pid4 := peerlist[3]
+	pid1 := peerlist[2]
+	pid2 := peerlist[3]
 
-	p.trackedPeers[pid1] = &peerStat{peerID: pid1, peerScore: 0.5}
-	p.trackedPeers[pid2] = &peerStat{peerID: pid2, peerScore: 10}
-	p.disconnectedPeers[pid3] = &peerStat{peerID: pid3, pruneDeadline: time.Now()}
-	p.disconnectedPeers[pid4] = &peerStat{peerID: pid4, pruneDeadline: time.Now().Add(time.Minute * 10)}
+	p.disconnectedPeers[pid1] = &peerStat{peerID: pid1, pruneDeadline: time.Now()}
+	p.disconnectedPeers[pid2] = &peerStat{peerID: pid2, pruneDeadline: time.Now().Add(time.Minute * 10)}
 	assert.True(t, len(p.trackedPeers) > 0)
 	assert.True(t, len(p.disconnectedPeers) > 0)
 
@@ -60,14 +55,13 @@ func TestPeerTracker_GC(t *testing.T) {
 	err = p.stop(ctx)
 	require.NoError(t, err)
 
-	// ensure amount of peers in trackedPeers is equal to minPeerTrackerSizeBeforeGC
-	require.Len(t, p.trackedPeers, minPeerTrackerSizeBeforeGC)
-	require.Nil(t, p.disconnectedPeers[pid3])
+	require.Len(t, p.trackedPeers, 10)
+	require.Nil(t, p.disconnectedPeers[pid1])
 
 	// ensure good peers were dumped to store
 	peers, err := pidstore.Load(ctx)
 	require.NoError(t, err)
-	require.Equal(t, minPeerTrackerSizeBeforeGC, len(peers))
+	require.Equal(t, 10, len(peers))
 }
 
 func TestPeerTracker_BlockPeer(t *testing.T) {

--- a/p2p/session.go
+++ b/p2p/session.go
@@ -213,6 +213,9 @@ func (s *session[H]) doRequest(
 			"err", err,
 			"peer", stat.peerID,
 		)
+		if errors.Is(err, header.ErrNotFound) {
+			s.queue.push(stat)
+		}
 		return
 	}
 

--- a/p2p/session.go
+++ b/p2p/session.go
@@ -213,6 +213,9 @@ func (s *session[H]) doRequest(
 			"err", err,
 			"peer", stat.peerID,
 		)
+		// ErrNotFound is not a critical error here. It means
+		// that peer hasn't synced the requested range yet.
+		// Returning peer to the queue, so it could serve another ranges.
 		if errors.Is(err, header.ErrNotFound) {
 			s.queue.push(stat)
 		}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Current PR fixing a case when the peerQueue becomes empty if all other peers are currently syncing. We had an incorrect assumption and didn't give a second chance to peers who were syncing.
Also, removed tracked peers pruning by score.  

Tested on robusta for 1 week. The network looks stable and healthy.
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
