### PR TITLE
fix(store): greedy heightSub cancellation

### DIFF
--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -172,7 +172,7 @@ func (ex *Exchange[H]) Head(ctx context.Context, opts ...header.HeadOption[H]) (
 				trace.WithAttributes(attribute.String("peerID", from.String())),
 			)
 			defer newSpan.End()
-			
+
 			headers, err := ex.request(reqCtx, from, headerReq)
 			if err != nil {
 				newSpan.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
So, I was playing around with similar code and taking heightSub as an inspiration. While writing that code, I realized that `heightSub` has a nasty bug. Basically, a subscription cancellation removes the other active subs for the same height, leaving them blocked forever. We could observe some abnormal blockings in the past, which may explain it.

I provided a test scenario that proves the issue existed and the fix works.