### PR TITLE
fix(p2p/peerTracker): remove timeout during bootstrapping 

### DIFF
--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -103,7 +103,7 @@ func (ex *Exchange[H]) Start(ctx context.Context) error {
 
 	// bootstrap the peerTracker with trusted peers as well as previously seen
 	// peers if provided.
-	return ex.peerTracker.bootstrap(ctx, ex.trustedPeers())
+	return ex.peerTracker.bootstrap(ex.trustedPeers())
 }
 
 func (ex *Exchange[H]) Stop(ctx context.Context) error {
@@ -172,7 +172,7 @@ func (ex *Exchange[H]) Head(ctx context.Context, opts ...header.HeadOption[H]) (
 				trace.WithAttributes(attribute.String("peerID", from.String())),
 			)
 			defer newSpan.End()
-			
+
 			headers, err := ex.request(reqCtx, from, headerReq)
 			if err != nil {
 				newSpan.SetStatus(codes.Error, err.Error())

--- a/p2p/peer_tracker.go
+++ b/p2p/peer_tracker.go
@@ -78,12 +78,9 @@ func newPeerTracker(
 //
 // NOTE: bootstrap is intended to be used with an on-disk peerstore.Peerstore as
 // the peerTracker needs access to the previously-seen peers' AddrInfo on start.
-func (p *peerTracker) bootstrap(ctx context.Context, trusted []libpeer.ID) error {
-	connectCtx, cancel := context.WithTimeout(context.Background(), time.Second*60)
-	defer cancel()
-
+func (p *peerTracker) bootstrap(trusted []libpeer.ID) error {
 	for _, trust := range trusted {
-		go p.connectToPeer(connectCtx, trust)
+		go p.connectToPeer(p.ctx, trust)
 	}
 
 	// short-circuit if pidstore was not provided
@@ -91,13 +88,13 @@ func (p *peerTracker) bootstrap(ctx context.Context, trusted []libpeer.ID) error
 		return nil
 	}
 
-	prevSeen, err := p.pidstore.Load(ctx)
+	prevSeen, err := p.pidstore.Load(p.ctx)
 	if err != nil {
 		return err
 	}
 
 	for _, peer := range prevSeen {
-		go p.connectToPeer(connectCtx, peer)
+		go p.connectToPeer(p.ctx, peer)
 	}
 	return nil
 }

--- a/p2p/peer_tracker.go
+++ b/p2p/peer_tracker.go
@@ -82,14 +82,8 @@ func (p *peerTracker) bootstrap(ctx context.Context, trusted []libpeer.ID) error
 	connectCtx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 	defer cancel()
 
-	wg := sync.WaitGroup{}
-	wg.Add(len(trusted))
 	for _, trust := range trusted {
-		trust := trust
-		go func() {
-			defer wg.Done()
-			p.connectToPeer(connectCtx, trust)
-		}()
+		go p.connectToPeer(connectCtx, trust)
 	}
 
 	// short-circuit if pidstore was not provided
@@ -102,15 +96,9 @@ func (p *peerTracker) bootstrap(ctx context.Context, trusted []libpeer.ID) error
 		return err
 	}
 
-	wg.Add(len(prevSeen))
 	for _, peer := range prevSeen {
-		peer := peer
-		go func() {
-			defer wg.Done()
-			p.connectToPeer(connectCtx, peer)
-		}()
+		go p.connectToPeer(connectCtx, peer)
 	}
-	wg.Wait()
 	return nil
 }
 

--- a/p2p/peer_tracker_test.go
+++ b/p2p/peer_tracker_test.go
@@ -105,7 +105,7 @@ func TestPeerTracker_Bootstrap(t *testing.T) {
 
 	go tracker.track()
 
-	err = tracker.bootstrap(ctx, prevSeen[:2])
+	err = tracker.bootstrap(prevSeen[:2])
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Removed timeout during bootstrap, as we agreed in dm. Also, instead of relying on the exchange context, bootstrap now relies on the peerTracker context.
