### PR TITLE
deps: bump hashicorp/golang-lru to v2 and move from ARC to 2Q cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ retract v0.1.0
 require (
 	github.com/celestiaorg/go-libp2p-messenger v0.2.0
 	github.com/gogo/protobuf v1.3.2
-	github.com/hashicorp/golang-lru/arc/v2 v2.0.7
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/libp2p/go-libp2p v0.33.2
@@ -35,7 +35,6 @@ require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20240207164012-fb44976bdcd5 // indirect
 	github.com/google/uuid v1.5.0 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ retract v0.1.0
 require (
 	github.com/celestiaorg/go-libp2p-messenger v0.2.0
 	github.com/gogo/protobuf v1.3.2
-	github.com/hashicorp/golang-lru v1.0.2
+	github.com/hashicorp/golang-lru/arc/v2 v2.0.7
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/libp2p/go-libp2p v0.33.2

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
-github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/arc/v2 v2.0.7 h1:QxkVTxwColcduO+LP7eJO56r2hFiG8zEbfAAzRv52KQ=
+github.com/hashicorp/golang-lru/arc/v2 v2.0.7/go.mod h1:Pe7gBlGdc8clY5LJ0LpJXMt5AmgmWNH1g+oFFVUHOEc=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,6 @@ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/golang-lru/arc/v2 v2.0.7 h1:QxkVTxwColcduO+LP7eJO56r2hFiG8zEbfAAzRv52KQ=
-github.com/hashicorp/golang-lru/arc/v2 v2.0.7/go.mod h1:Pe7gBlGdc8clY5LJ0LpJXMt5AmgmWNH1g+oFFVUHOEc=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/store/height_indexer.go
+++ b/store/height_indexer.go
@@ -3,7 +3,7 @@ package store
 import (
 	"context"
 
-	"github.com/hashicorp/golang-lru/arc/v2"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/ipfs/go-datastore"
 
 	"github.com/celestiaorg/go-header"
@@ -14,12 +14,12 @@ import (
 // Hash.
 type heightIndexer[H header.Header[H]] struct {
 	ds    datastore.Batching
-	cache *arc.ARCCache[uint64, header.Hash]
+	cache *lru.TwoQueueCache[uint64, header.Hash]
 }
 
 // newHeightIndexer creates new heightIndexer.
 func newHeightIndexer[H header.Header[H]](ds datastore.Batching, indexCacheSize int) (*heightIndexer[H], error) {
-	cache, err := arc.NewARC[uint64, header.Hash](indexCacheSize)
+	cache, err := lru.New2Q[uint64, header.Hash](indexCacheSize)
 	if err != nil {
 		return nil, err
 	}

--- a/store/height_indexer.go
+++ b/store/height_indexer.go
@@ -3,7 +3,7 @@ package store
 import (
 	"context"
 
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/golang-lru/arc/v2"
 	"github.com/ipfs/go-datastore"
 
 	"github.com/celestiaorg/go-header"
@@ -14,12 +14,12 @@ import (
 // Hash.
 type heightIndexer[H header.Header[H]] struct {
 	ds    datastore.Batching
-	cache *lru.ARCCache
+	cache *arc.ARCCache[uint64, header.Hash]
 }
 
 // newHeightIndexer creates new heightIndexer.
 func newHeightIndexer[H header.Header[H]](ds datastore.Batching, indexCacheSize int) (*heightIndexer[H], error) {
-	cache, err := lru.NewARC(indexCacheSize)
+	cache, err := arc.NewARC[uint64, header.Hash](indexCacheSize)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func newHeightIndexer[H header.Header[H]](ds datastore.Batching, indexCacheSize 
 // HashByHeight loads a header hash corresponding to the given height.
 func (hi *heightIndexer[H]) HashByHeight(ctx context.Context, h uint64) (header.Hash, error) {
 	if v, ok := hi.cache.Get(h); ok {
-		return v.(header.Hash), nil
+		return v, nil
 	}
 
 	val, err := hi.ds.Get(ctx, heightKey(h))

--- a/store/store.go
+++ b/store/store.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/golang-lru/arc/v2"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	logging "github.com/ipfs/go-log/v2"
@@ -31,7 +31,7 @@ type Store[H header.Header[H]] struct {
 	// underlying KV store
 	ds datastore.Batching
 	// adaptive replacement cache of headers
-	cache *arc.ARCCache[string, H]
+	cache *lru.TwoQueueCache[string, H]
 	// metrics collection instance
 	metrics *metrics
 
@@ -89,7 +89,7 @@ func newStore[H header.Header[H]](ds datastore.Batching, opts ...Option) (*Store
 		return nil, fmt.Errorf("header/store: store creation failed: %w", err)
 	}
 
-	cache, err := arc.NewARC[string, H](params.StoreCacheSize)
+	cache, err := lru.New2Q[string, H](params.StoreCacheSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create index cache: %w", err)
 	}


### PR DESCRIPTION
## Overview

This PR updates the major version of `github.com/hashicorp/golang-lru` from `v1` to `v2`. The biggest improvement is support for generics. So, we can experience a bit better performance due to fewer allocations than `v1` (where every value was wrapped in `interface{}`, which causes allocation in most cases).

I'm not sure if I should prove my words with benchmarks 'cause the `golang-lru` authors didn't post any benchmarks. 

Also here: moving from ARC cache to 2Q (two queue) to avoid potential issues with ARC patent.