### PR TITLE
fix(store): stop doing header verification in GetRangeByHeight

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -260,14 +260,6 @@ func (s *Store[H]) GetRangeByHeight(
 	if err != nil {
 		return nil, err
 	}
-
-	for _, h := range headers {
-		err := from.Verify(h)
-		if err != nil {
-			return nil, err
-		}
-		from = h
-	}
 	return headers, nil
 }
 


### PR DESCRIPTION

## Overview

We don't need to verify headers on every `GetRangeByHeight` 'cause verification already happened in `Append`. No tests failed, added `TestStore_Append_BadHeader` to prevent bugs in the future.

Fixes #135 
