### PR TITLE
fix: use errors.New for const errors

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -52,7 +52,7 @@ var (
 	ErrNotFound = errors.New("header: not found")
 
 	// ErrNoHead is returned when Store is empty (does not contain any known header).
-	ErrNoHead = fmt.Errorf("header/store: no chain head")
+	ErrNoHead = errors.New("header/store: no chain head")
 
 	// ErrHeadersLimitExceeded is returned when ExchangeServer receives header request for more
 	// than maxRequestSize headers.

--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -261,7 +261,7 @@ func (ex *Exchange[H]) GetByHeight(ctx context.Context, height uint64) (H, error
 	var zero H
 	// sanity check height
 	if height == 0 {
-		err := fmt.Errorf("specified request height must be greater than 0")
+		err := errors.New("specified request height must be greater than 0")
 		span.SetStatus(codes.Error, err.Error())
 		return zero, err
 	}
@@ -349,7 +349,7 @@ func (ex *Exchange[H]) performRequest(
 
 	trustedPeers := ex.trustedPeers()
 	if len(trustedPeers) == 0 {
-		return nil, fmt.Errorf("no trusted peers")
+		return nil, errors.New("no trusted peers")
 	}
 
 	var reqErr error

--- a/p2p/subscriber.go
+++ b/p2p/subscriber.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -153,7 +152,7 @@ func (s *Subscriber[H]) SetVerifier(val func(context.Context, H) error) error {
 // topic.
 func (s *Subscriber[H]) Subscribe() (header.Subscription[H], error) {
 	if s.topic == nil {
-		return nil, fmt.Errorf("header topic is not instantiated, service must be started before subscribing")
+		return nil, errors.New("header topic is not instantiated, service must be started before subscribing")
 	}
 
 	return newSubscription[H](s.topic, s.metrics)

--- a/store/store.go
+++ b/store/store.go
@@ -128,7 +128,7 @@ func newStore[H header.Header[H]](ds datastore.Batching, opts ...Option) (*Store
 
 func (s *Store[H]) Init(ctx context.Context, initial H) error {
 	if s.heightSub.Height() != 0 {
-		return fmt.Errorf("store already initialized")
+		return errors.New("store already initialized")
 	}
 	// trust the given header as the initial head
 	err := s.flush(ctx, initial)
@@ -223,7 +223,7 @@ func (s *Store[H]) Get(ctx context.Context, hash header.Hash) (H, error) {
 func (s *Store[H]) GetByHeight(ctx context.Context, height uint64) (H, error) {
 	var zero H
 	if height == 0 {
-		return zero, fmt.Errorf("header/store: height must be bigger than zero")
+		return zero, errors.New("header/store: height must be bigger than zero")
 	}
 	// if the requested 'height' was not yet published
 	// we subscribe to it

--- a/sync/sync_getter_test.go
+++ b/sync/sync_getter_test.go
@@ -2,7 +2,7 @@ package sync
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -41,7 +41,7 @@ func TestSyncGetterHead(t *testing.T) {
 	assert.EqualValues(t, 1, fex.hits.Load())
 }
 
-var errFakeHead = fmt.Errorf("head")
+var errFakeHead = errors.New("head")
 
 type fakeGetter[H header.Header[H]] struct {
 	hits atomic.Uint32


### PR DESCRIPTION
## Overview

Small cleanup PR. Use `errors.New` when parameter is const (instead of `fmt.Errorf`).