### PR TITLE
fix(store): make heightIndexer.IndexTo as a func

### DIFF
--- a/store/height_indexer.go
+++ b/store/height_indexer.go
@@ -44,15 +44,3 @@ func (hi *heightIndexer[H]) HashByHeight(ctx context.Context, h uint64) (header.
 	hi.cache.Add(h, header.Hash(val))
 	return val, nil
 }
-
-// IndexTo saves mapping between header Height and Hash to the given batch.
-func (hi *heightIndexer[H]) IndexTo(ctx context.Context, batch datastore.Batch, headers ...H) error {
-	for _, h := range headers {
-		err := batch.Put(ctx, heightKey(h.Height()), h.Hash())
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}


### PR DESCRIPTION
## Overview

`heightIndexer.IndexTo` method doesn't use `heightIndexer` fields, this method can be a simple function. This happened during refactoring, at some point `batch` parameter landed and field became obsolete. So, a small cleanup.