### PR TITLE
docs: document trusted header in Verify

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -11,8 +11,9 @@ import (
 const DefaultHeightThreshold uint64 = 80000 // ~ 14 days of 15 second headers
 
 // Verify verifies untrusted Header against trusted following general Header checks and
-// custom user-specific checks defined in Header.Verify
+// custom user-specific checks defined in Header.Verify.
 //
+// If trusted header is zero, no error is returned.
 // If heightThreshold is zero, uses DefaultHeightThreshold.
 // Always returns VerifyError.
 func Verify[H Header[H]](trstd, untrstd H, heightThreshold uint64) error {


### PR DESCRIPTION
## Overview

This was shortly discussed with @renaynay. We agreed on documenting that zero trusted header is allowed but untrusted header cannot be zero. Theoretically we can enforce non-zero headers for both but this requires a bit wider discussion inside the team (which we can make in this PR). 