### PR TITLE
feat(sync, store)!: Remove adjacency requirement from Store.Append

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -3,7 +3,6 @@ package header
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
@@ -59,16 +58,6 @@ var (
 	ErrHeadersLimitExceeded = errors.New("header/p2p: header limit per 1 request exceeded")
 )
 
-// ErrNonAdjacent is returned when Store is appended with a header not adjacent to the stored head.
-type ErrNonAdjacent struct {
-	Head      uint64
-	Attempted uint64
-}
-
-func (ena *ErrNonAdjacent) Error() string {
-	return fmt.Sprintf("header/store: non-adjacent: head %d, attempted %d", ena.Head, ena.Attempted)
-}
-
 // Store encompasses the behavior necessary to store and retrieve Headers
 // from a node's local storage.
 type Store[H Header[H]] interface {
@@ -88,10 +77,6 @@ type Store[H Header[H]] interface {
 	HasAt(context.Context, uint64) bool
 
 	// Append stores and verifies the given Header(s).
-	// It requires them to be adjacent and in ascending order,
-	// as it applies them contiguously on top of the current head height.
-	// It returns the amount of successfully applied headers,
-	// so caller can understand what given header was invalid, if any.
 	Append(context.Context, ...H) error
 
 	// GetRange returns the range [from:to).

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -92,7 +92,7 @@ func (hs *heightSub[H]) Pub(headers ...H) {
 	height := hs.Height()
 	from, to := headers[0].Height(), headers[ln-1].Height()
 	if height+1 != from && height != 0 { // height != 0 is needed to enable init from any height and not only 1
-		// log.Fatalf("PLEASE FILE A BUG REPORT: headers given to the heightSub are in the wrong order: expected %d, got %d", height+1, from)
+		log.Fatalf("PLEASE FILE A BUG REPORT: headers given to the heightSub are in the wrong order: expected %d, got %d", height+1, from)
 		return
 	}
 	hs.SetHeight(to)

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -92,7 +92,7 @@ func (hs *heightSub[H]) Pub(headers ...H) {
 	height := hs.Height()
 	from, to := headers[0].Height(), headers[ln-1].Height()
 	if height+1 != from && height != 0 { // height != 0 is needed to enable init from any height and not only 1
-		log.Fatalf("PLEASE FILE A BUG REPORT: headers given to the heightSub are in the wrong order: expected %d, got %d", height+1, from)
+		// log.Fatalf("PLEASE FILE A BUG REPORT: headers given to the heightSub are in the wrong order: expected %d, got %d", height+1, from)
 		return
 	}
 	hs.SetHeight(to)

--- a/store/store.go
+++ b/store/store.go
@@ -322,14 +322,6 @@ func (s *Store[H]) Append(ctx context.Context, headers ...H) error {
 	// collect valid headers
 	verified := make([]H, 0, lh)
 	for i, h := range headers {
-		// currently store requires all headers to be appended sequentially and adjacently
-		// TODO(@Wondertan): Further pruning friendly Store design should reevaluate this requirement
-		// if h.Height() != head.Height()+1 {
-		// 	return &header.ErrNonAdjacent{
-		// 		Head:      head.Height(),
-		// 		Attempted: h.Height(),
-		// 	}
-		// }
 
 		err = head.Verify(h)
 		if err != nil {
@@ -350,7 +342,8 @@ func (s *Store[H]) Append(ctx context.Context, headers ...H) error {
 			// otherwise, stop the loop and apply headers appeared to be valid
 			break
 		}
-		verified, head = append(verified, h), h
+		verified = append(verified, h)
+		head = h
 	}
 
 	onWrite := func() {

--- a/store/store.go
+++ b/store/store.go
@@ -324,12 +324,12 @@ func (s *Store[H]) Append(ctx context.Context, headers ...H) error {
 	for i, h := range headers {
 		// currently store requires all headers to be appended sequentially and adjacently
 		// TODO(@Wondertan): Further pruning friendly Store design should reevaluate this requirement
-		if h.Height() != head.Height()+1 {
-			return &header.ErrNonAdjacent{
-				Head:      head.Height(),
-				Attempted: h.Height(),
-			}
-		}
+		// if h.Height() != head.Height()+1 {
+		// 	return &header.ErrNonAdjacent{
+		// 		Head:      head.Height(),
+		// 		Attempted: h.Height(),
+		// 	}
+		// }
 
 		err = head.Verify(h)
 		if err != nil {

--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -119,8 +119,8 @@ func (s *Syncer[H]) setSubjectiveHead(ctx context.Context, netHead H) {
 	//  * Remove ErrNonAdjacent
 	//  * Remove writeHead from the canonical store implementation
 	err := s.store.Append(ctx, netHead)
-	var nonAdj *header.ErrNonAdjacent
-	if err != nil && !errors.As(err, &nonAdj) {
+	// var nonAdj *header.ErrNonAdjacent
+	if err != nil { //&& !errors.As(err, &nonAdj) {
 		// might be a storage error or something else, but we can still try to continue processing netHead
 		log.Errorw("storing new network header",
 			"height", netHead.Height(),

--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -119,8 +119,8 @@ func (s *Syncer[H]) setSubjectiveHead(ctx context.Context, netHead H) {
 	//  * Remove ErrNonAdjacent
 	//  * Remove writeHead from the canonical store implementation
 	err := s.store.Append(ctx, netHead)
-	// var nonAdj *header.ErrNonAdjacent
-	if err != nil { //&& !errors.As(err, &nonAdj) {
+	var nonAdj *errNonAdjacent
+	if err != nil && !errors.As(err, &nonAdj) {
 		// might be a storage error or something else, but we can still try to continue processing netHead
 		log.Errorw("storing new network header",
 			"height", netHead.Height(),

--- a/sync/sync_store.go
+++ b/sync/sync_store.go
@@ -2,10 +2,22 @@ package sync
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync/atomic"
 
 	"github.com/celestiaorg/go-header"
 )
+
+// errNonAdjacent is returned when syncer is appended with a header not adjacent to the stored head.
+type errNonAdjacent struct {
+	Head      uint64
+	Attempted uint64
+}
+
+func (ena *errNonAdjacent) Error() string {
+	return fmt.Sprintf("sync: non-adjacent: head %d, attempted %d", ena.Head, ena.Attempted)
+}
 
 // syncStore is a Store wrapper that provides synchronization over writes and reads
 // for Head of underlying Store. Useful for Stores that do not guarantee synchrony between Append
@@ -31,6 +43,25 @@ func (s *syncStore[H]) Head(ctx context.Context) (H, error) {
 }
 
 func (s *syncStore[H]) Append(ctx context.Context, headers ...H) error {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	head, err := s.Head(ctx)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		panic(err)
+	}
+
+	for _, h := range headers {
+		if h.Height() != head.Height()+1 {
+			return &errNonAdjacent{
+				Head:      head.Height(),
+				Attempted: h.Height(),
+			}
+		}
+		head = h
+	}
+
 	if err := s.Store.Append(ctx, headers...); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Overview

Things that gonna change after we drop adjacency requirement from `Store.Append`:
- Obviously dropping `ErrNonAdjacent` (breaking change).
- `Store.Append` comment is **already** outdated (looks like there were 2 return params)
- `store.Store.Append` will not verify for adjacency (obviously)
- `Syncer.setSubjectiveHead` will not verify for `ErrNonAdjacent`
- adjacency check is happening in `sync` instead of `store`.

Fixes #32 