### PR TITLE
refactor(store,sync)!: drop `NewStoreWithHead`

### DIFF
--- a/store/init_test.go
+++ b/store/init_test.go
@@ -20,13 +20,13 @@ func TestInitStore_NoReinit(t *testing.T) {
 
 	suite := headertest.NewTestSuite(t)
 	head := suite.Head()
-	exchange := local.NewExchange(NewTestStore(ctx, t, head))
 
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	exchange := local.NewExchange(NewTestStore(t, ctx, ds, head))
 	store, err := NewStore[*headertest.DummyHeader](ds)
 	require.NoError(t, err)
 
-	err = Init[*headertest.DummyHeader](ctx, store, exchange, head.Hash())
+	err = Init(ctx, store, exchange, head.Hash())
 	assert.NoError(t, err)
 
 	err = store.Start(ctx)

--- a/store/testing.go
+++ b/store/testing.go
@@ -5,24 +5,27 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/go-header/headertest"
 )
 
 // NewTestStore creates initialized and started in memory header Store which is useful for testing.
-func NewTestStore(ctx context.Context, t *testing.T, head *headertest.DummyHeader) header.Store[*headertest.DummyHeader] {
-	store, err := NewStoreWithHead(ctx, sync.MutexWrap(datastore.NewMapDatastore()), head)
-	require.NoError(t, err)
+func NewTestStore(tb testing.TB, ctx context.Context,
+	ds datastore.Batching, head *headertest.DummyHeader, opts ...Option,
+) *Store[*headertest.DummyHeader] {
+	store, err := NewStore[*headertest.DummyHeader](ds, opts...)
+	require.NoError(tb, err)
+
+	err = store.Init(ctx, head)
+	require.NoError(tb, err)
 
 	err = store.Start(ctx)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		err := store.Stop(ctx)
-		require.NoError(t, err)
+		require.NoError(tb, err)
 	})
 	return store
 }

--- a/sync/sync_head_test.go
+++ b/sync/sync_head_test.go
@@ -7,15 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-datastore"
-	sync2 "github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/go-header/headertest"
 	"github.com/celestiaorg/go-header/local"
-	"github.com/celestiaorg/go-header/store"
 )
 
 func TestSyncer_incomingNetworkHeadRaces(t *testing.T) {
@@ -61,11 +58,10 @@ func TestSyncer_HeadWithTrustedHead(t *testing.T) {
 	suite := headertest.NewTestSuite(t)
 	head := suite.Head()
 
-	localStore := store.NewTestStore(ctx, t, head)
+	localStore := newTestStore(t, ctx, head)
+	remoteStore := newTestStore(t, ctx, head)
 
-	remoteStore, err := store.NewStoreWithHead(ctx, sync2.MutexWrap(datastore.NewMapDatastore()), head)
-	require.NoError(t, err)
-	err = remoteStore.Append(ctx, suite.GenDummyHeaders(100)...)
+	err := remoteStore.Append(ctx, suite.GenDummyHeaders(100)...)
 	require.NoError(t, err)
 
 	// create a wrappedGetter to track exchange interactions


### PR DESCRIPTION
## Overview

Drop `store.NewStoreWithHead`. Replace it with a test helpers where appropriate. `store` package now has `newStoreWithHead`, `sync` has `newTestStore`. Both now require `tb testing.TB` as a 1st param which simplifies usage for the future tests and benchmarks.

Fixes #188 