### PR TITLE
refactor(p2p): simplify sendMessage

### DIFF
--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -384,8 +384,11 @@ func (ex *Exchange[H]) request(
 	req *p2p_pb.HeaderRequest,
 ) ([]H, error) {
 	log.Debugw("requesting peer", "peer", to)
-	responses, size, duration, err := sendMessage(ctx, ex.host, to, ex.protocolID, req)
-	ex.metrics.response(ctx, size, duration, err)
+	start := time.Now()
+	responses, size, err := sendMessage(ctx, ex.host, to, ex.protocolID, req)
+	took := time.Since(start)
+
+	ex.metrics.response(ctx, size, took, err)
 	if err != nil {
 		log.Debugw("err sending request", "peer", to, "err", err)
 		return nil, err

--- a/p2p/helpers.go
+++ b/p2p/helpers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -51,11 +50,10 @@ func sendMessage(
 	to peer.ID,
 	protocol protocol.ID,
 	req *p2p_pb.HeaderRequest,
-) ([]*p2p_pb.HeaderResponse, uint64, time.Duration, error) {
-	startTime := time.Now()
+) ([]*p2p_pb.HeaderResponse, uint64, error) {
 	stream, err := host.NewStream(ctx, to, protocol)
 	if err != nil {
-		return nil, 0, 0, fmt.Errorf("header/p2p: failed to open a new stream: %w", err)
+		return nil, 0, fmt.Errorf("header/p2p: failed to open a new stream: %w", err)
 	}
 
 	// set stream deadline from the context deadline.
@@ -71,12 +69,12 @@ func sendMessage(
 	_, err = serde.Write(stream, req)
 	if err != nil {
 		stream.Reset() //nolint:errcheck
-		return nil, 0, 0, fmt.Errorf("header/p2p: failed to write a request: %w", err)
+		return nil, 0, fmt.Errorf("header/p2p: failed to write a request: %w", err)
 	}
 
 	err = stream.CloseWrite()
 	if err != nil {
-		return nil, 0, 0, err
+		return nil, 0, err
 	}
 
 	headers := make([]*p2p_pb.HeaderResponse, 0)
@@ -112,7 +110,7 @@ func sendMessage(
 		// reset stream in case of an error
 		stream.Reset() //nolint:errcheck
 	}
-	return headers, totalRespLn, time.Since(startTime), err
+	return headers, totalRespLn, err
 }
 
 // convertStatusCodeToError converts passed status code into an error.


### PR DESCRIPTION


## Overview

`sendMessage` was doing a bit too much, observability could happen on the caller side, which easier to adapt and extend in the future.

Also, dropping 1 `if` in `processResponses` 'cause it's always `false`. And slice prealloc, looks harmless.