### PR TITLE
feat(store): check first header is adjacent to the written header

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -20,8 +20,12 @@ var log = logging.Logger("header/store")
 var (
 	// defaultStorePrefix defines default datastore prefix
 	defaultStorePrefix = datastore.NewKey("headers")
+
 	// errStoppedStore is returned for attempted operations on a stopped store
 	errStoppedStore = errors.New("stopped store")
+
+	// errNewHeaderNonAdj indicates that the 1st header is not adjacent to the written header.
+	errNewHeaderNonAdj = errors.New("first header is not adjacent to the head")
 )
 
 // Store implements the Store interface for Headers over Datastore.
@@ -317,6 +321,10 @@ func (s *Store[H]) Append(ctx context.Context, headers ...H) error {
 		}
 	} else {
 		head = *headPtr
+	}
+
+	if head.Height()+1 != headers[0].Height() {
+		return errNewHeaderNonAdj
 	}
 
 	// collect valid headers

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -141,6 +141,20 @@ func TestStore_Append_BadHeader(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestStore_Append_NonAdjacent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	store := NewTestStore(t, ctx, ds, suite.Head())
+
+	in := suite.GenDummyHeaders(10)[1:]
+	err := store.Append(ctx, in...)
+	require.ErrorIs(t, err, errNewHeaderNonAdj)
+}
+
 // TestStore_GetRange tests possible combinations of requests and ensures that
 // the store can handle them adequately (even malformed requests)
 func TestStore_GetRange(t *testing.T) {


### PR DESCRIPTION

## Overview

Small extra step to exit earlier when the header cannot be applied 'cause it's not adjacent to the head. This might seen as a controversial change but this is how the code behaves now.