### PR TITLE
feat(store): add tail header

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -51,6 +51,8 @@ type Store[H header.Header[H]] struct {
 	writesDn chan struct{}
 	// writeHead maintains the current write head
 	writeHead atomic.Pointer[H]
+	// tailHeader maintains the current tail header.
+	tailHeader atomic.Pointer[H]
 	// pending keeps headers pending to be written in one batch
 	pending *batch[H]
 
@@ -120,6 +122,8 @@ func (s *Store[H]) Init(ctx context.Context, initial H) error {
 	if err != nil {
 		return err
 	}
+
+	s.tailHeader.Store(&initial)
 
 	log.Infow("initialized head", "height", initial.Height(), "hash", initial.Hash())
 	s.heightSub.Pub(initial)


### PR DESCRIPTION

## Overview

Add `tailHeader` as a part of backward sync. Currently it's initialized to initial header and isn't exported. Harmless addition to simplify future PRs.