### PR TITLE
refactor(sync): simplify isExpired

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Test & Coverage
       run: |
         go install github.com/ory/go-acc@v0.2.6
-        go-acc -o coverage.txt ./... -- -count=100 -run=^TestSyncSimpleRequestingHead$ -v --race
+        go-acc -o coverage.txt ./... -- -v --race
 
     - uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Test & Coverage
       run: |
         go install github.com/ory/go-acc@v0.2.6
-        go-acc -o coverage.txt ./... -- -v --race
+        go-acc -o coverage.txt ./... -- -count=100 -run=^TestSyncSimpleRequestingHead$ -v --race
 
     - uses: codecov/codecov-action@v3
       with:

--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -198,7 +198,7 @@ func (s *Syncer[H]) verify(ctx context.Context, newHead H) (bool, error) {
 // isExpired checks if header is expired against trusting period.
 func isExpired[H header.Header[H]](header H, period time.Duration) bool {
 	expirationTime := header.Time().Add(period)
-	return !expirationTime.After(time.Now())
+	return expirationTime.Before(time.Now())
 }
 
 // isRecent checks if header is recent against the given recency threshold.

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -43,7 +43,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 	err = syncer.Start(ctx)
 	require.NoError(t, err)
 
-	time.Sleep(time.Millisecond * 10) // needs some to realize it is syncing
+	time.Sleep(time.Millisecond * 100) // needs some to realize it is syncing
 	err = syncer.SyncWait(ctx)
 	require.NoError(t, err)
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -37,7 +37,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 		headertest.NewDummySubscriber(),
 		WithBlockTime(time.Second*30),
 		WithRecencyThreshold(time.Second*35), // add 5 second buffer
-		WithTrustingPeriod(time.Second),
+		WithTrustingPeriod(5*time.Second),
 	)
 	require.NoError(t, err)
 	err = syncer.Start(ctx)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -37,7 +37,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 		headertest.NewDummySubscriber(),
 		WithBlockTime(time.Second*30),
 		WithRecencyThreshold(time.Second*35), // add 5 second buffer
-		WithTrustingPeriod(time.Microsecond),
+		WithTrustingPeriod(10*time.Millisecond),
 	)
 	require.NoError(t, err)
 	err = syncer.Start(ctx)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -37,7 +37,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 		headertest.NewDummySubscriber(),
 		WithBlockTime(time.Second*30),
 		WithRecencyThreshold(time.Second*35), // add 5 second buffer
-		WithTrustingPeriod(5*time.Second),
+		WithTrustingPeriod(time.Microsecond),
 	)
 	require.NoError(t, err)
 	err = syncer.Start(ctx)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -37,7 +37,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 		headertest.NewDummySubscriber(),
 		WithBlockTime(time.Second*30),
 		WithRecencyThreshold(time.Second*35), // add 5 second buffer
-		WithTrustingPeriod(100*time.Millisecond),
+		WithTrustingPeriod(time.Second),
 	)
 	require.NoError(t, err)
 	err = syncer.Start(ctx)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -37,7 +37,7 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 		headertest.NewDummySubscriber(),
 		WithBlockTime(time.Second*30),
 		WithRecencyThreshold(time.Second*35), // add 5 second buffer
-		WithTrustingPeriod(10*time.Millisecond),
+		WithTrustingPeriod(100*time.Millisecond),
 	)
 	require.NoError(t, err)
 	err = syncer.Start(ctx)


### PR DESCRIPTION
## Overview

Make it easier to understand. Also, slightly increasing sleep duration in `sync.TestSyncSimpleRequestingHead` to make test less flaky.