### PR TITLE
fix(store): properly update store head

### DIFF
--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -33,7 +34,7 @@ func (hs *heightSub[H]) isInited() bool {
 }
 
 // setHeight sets the new head height for heightSub.
-// Only higher then current height will be set.
+// Only higher than current height can be set.
 func (hs *heightSub[H]) setHeight(height uint64) {
 	for {
 		curr := hs.height.Load()
@@ -98,6 +99,10 @@ func (hs *heightSub[H]) Pub(headers ...H) {
 	}
 
 	from, to := headers[0].Height(), headers[ln-1].Height()
+	if from >= to {
+		panic(fmt.Sprintf("from must be lower than to, have: %d and %d", from, to))
+	}
+
 	hs.setHeight(to)
 
 	hs.heightReqsLk.Lock()

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -99,7 +99,7 @@ func (hs *heightSub[H]) Pub(headers ...H) {
 	}
 
 	from, to := headers[0].Height(), headers[ln-1].Height()
-	if from >= to {
+	if from > to {
 		panic(fmt.Sprintf("from must be lower than to, have: %d and %d", from, to))
 	}
 

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -34,8 +34,17 @@ func (hs *heightSub[H]) Height() uint64 {
 }
 
 // SetHeight sets the new head height for heightSub.
+// Only higher then current height will be set.
 func (hs *heightSub[H]) SetHeight(height uint64) {
-	hs.height.Store(height)
+	for {
+		curr := hs.height.Load()
+		if curr >= height {
+			return
+		}
+		if hs.height.CompareAndSwap(curr, height) {
+			return
+		}
+	}
 }
 
 // Sub subscribes for a header of a given height.

--- a/store/heightsub_test.go
+++ b/store/heightsub_test.go
@@ -20,7 +20,7 @@ func TestHeightSub(t *testing.T) {
 	{
 		h := headertest.RandDummyHeader(t)
 		h.HeightI = 100
-		hs.SetHeight(99)
+		hs.setHeight(99)
 		hs.Pub(h)
 
 		h, err := hs.Sub(ctx, 10)
@@ -56,7 +56,7 @@ func TestHeightSubNonAdjacement(t *testing.T) {
 	{
 		h := headertest.RandDummyHeader(t)
 		h.HeightI = 100
-		hs.SetHeight(99)
+		hs.setHeight(99)
 		hs.Pub(h)
 	}
 
@@ -76,6 +76,36 @@ func TestHeightSubNonAdjacement(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, h)
 	}
+}
+
+func TestHeightSub_monotonicHeight(t *testing.T) {
+	hs := newHeightSub[*headertest.DummyHeader]()
+
+	{
+		h := headertest.RandDummyHeader(t)
+		h.HeightI = 100
+		hs.setHeight(99)
+		hs.Pub(h)
+	}
+
+	{
+		h1 := headertest.RandDummyHeader(t)
+		h1.HeightI = 200
+		h2 := headertest.RandDummyHeader(t)
+		h2.HeightI = 300
+		hs.Pub(h1, h2)
+	}
+
+	{
+
+		h1 := headertest.RandDummyHeader(t)
+		h1.HeightI = 120
+		h2 := headertest.RandDummyHeader(t)
+		h2.HeightI = 130
+		hs.Pub(h1, h2)
+	}
+
+	assert.Equal(t, hs.height.Load(), uint64(300))
 }
 
 func TestHeightSubCancellation(t *testing.T) {

--- a/store/heightsub_test.go
+++ b/store/heightsub_test.go
@@ -47,6 +47,37 @@ func TestHeightSub(t *testing.T) {
 	}
 }
 
+func TestHeightSubNonAdjacement(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	hs := newHeightSub[*headertest.DummyHeader]()
+
+	{
+		h := headertest.RandDummyHeader(t)
+		h.HeightI = 100
+		hs.SetHeight(99)
+		hs.Pub(h)
+	}
+
+	{
+		go func() {
+			// fixes flakiness on CI
+			time.Sleep(time.Millisecond)
+
+			h1 := headertest.RandDummyHeader(t)
+			h1.HeightI = 200
+			h2 := headertest.RandDummyHeader(t)
+			h2.HeightI = 300
+			hs.Pub(h1, h2)
+		}()
+
+		h, err := hs.Sub(ctx, 200)
+		assert.NoError(t, err)
+		assert.NotNil(t, h)
+	}
+}
+
 func TestHeightSubCancellation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/store/heightsub_test.go
+++ b/store/heightsub_test.go
@@ -47,6 +47,7 @@ func TestHeightSub(t *testing.T) {
 	}
 }
 
+// Test heightSub can accept non-adj headers without a problem.
 func TestHeightSubNonAdjacement(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()

--- a/store/store.go
+++ b/store/store.go
@@ -180,8 +180,7 @@ func (s *Store[H]) Height() uint64 {
 
 	head, err := s.Head(ctx)
 	if err != nil {
-		// TODO(cristaloleg): log? panic? retry?
-		return 0
+		panic(err)
 	}
 	return head.Height()
 }
@@ -333,7 +332,7 @@ func (s *Store[H]) Append(ctx context.Context, headers ...H) error {
 		}
 		// store header from the disk.
 		gotHead := head
-		s.writeHead.CompareAndSwap(nil, &gotHead)
+		s.writeHead.Store(&gotHead)
 	} else {
 		head = *headPtr
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -173,6 +173,7 @@ func (s *Store[H]) Height() uint64 {
 	head, err := s.Head(ctx)
 	if err != nil {
 		if errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded) ||
 			errors.Is(err, datastore.ErrNotFound) {
 			return 0
 		}
@@ -528,7 +529,8 @@ func (s *Store[H]) tryAdvanceHead(ctx context.Context, headers ...H) {
 		currHeight++
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	// TODO(cristaloleg): benchmark this timeout or make it dynamic.
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	// advance based on already written headers.

--- a/store/store.go
+++ b/store/store.go
@@ -170,7 +170,15 @@ func (s *Store[H]) Stop(ctx context.Context) error {
 }
 
 func (s *Store[H]) Height() uint64 {
-	return s.heightSub.Height()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	head, err := s.Head(ctx)
+	if err != nil {
+		// TODO(cristaloleg): log? panic? retry?
+		return 0
+	}
+	return head.Height()
 }
 
 // Head returns the highest contiguous header written to the store.

--- a/store/store.go
+++ b/store/store.go
@@ -180,6 +180,10 @@ func (s *Store[H]) Height() uint64 {
 
 	head, err := s.Head(ctx)
 	if err != nil {
+		if errors.Is(err, context.Canceled) ||
+			errors.Is(err, datastore.ErrNotFound) {
+			return 0
+		}
 		panic(err)
 	}
 	return head.Height()

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -196,16 +196,17 @@ func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
 		t.Log("head", head.Height(), head.Hash())
 		assert.Equal(t, head.Hash(), wantHead.Hash())
 	}
-	// {
-	// 	err := store.Append(ctx, missedChunk...)
-	// 	require.NoError(t, err)
-	// 	// wait for batch to be written.
-	// 	time.Sleep(100 * time.Millisecond)
-	// 	// after appending missing headers we're on the latest header.
-	// 	head, err := store.Head(ctx)
-	// 	require.NoError(t, err)
-	// 	assert.Equal(t, head.Hash(), latestHead.Hash())
-	// }
+	{
+		err := store.Append(ctx, missedChunk...)
+		require.NoError(t, err)
+		// wait for batch to be written.
+		time.Sleep(100 * time.Millisecond)
+
+		// after appending missing headers we're on the latest header.
+		head, err := store.Head(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, head.Hash(), latestHead.Hash())
+	}
 }
 
 // TestStore_GetRange tests possible combinations of requests and ensures that

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -248,7 +248,7 @@ func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
 		err := store.Append(ctx, missedChunk...)
 		require.NoError(t, err)
 		// wait for batch to be written.
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(time.Second)
 
 		// after appending missing headers we're on the latest header.
 		head, err := store.Head(ctx)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -155,11 +155,22 @@ func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
 	assert.Equal(t, head.Hash(), suite.Head().Hash())
 
 	firstChunk := suite.GenDummyHeaders(5)
+	for i := range firstChunk {
+		t.Log("firstChunk:", firstChunk[i].Height(), firstChunk[i].Hash())
+	}
 	missedChunk := suite.GenDummyHeaders(5)
+	for i := range missedChunk {
+		t.Log("missedChunk:", missedChunk[i].Height(), missedChunk[i].Hash())
+	}
 	lastChunk := suite.GenDummyHeaders(5)
+	for i := range lastChunk {
+		t.Log("lastChunk:", lastChunk[i].Height(), lastChunk[i].Hash())
+	}
 
 	wantHead := firstChunk[len(firstChunk)-1]
+	t.Log("wantHead", wantHead.Height(), wantHead.Hash())
 	latestHead := lastChunk[len(lastChunk)-1]
+	t.Log("latestHead", latestHead.Height(), latestHead.Hash())
 
 	{
 		err := store.Append(ctx, firstChunk...)
@@ -172,7 +183,6 @@ func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, head.Hash(), wantHead.Hash())
 	}
-
 	{
 		err := store.Append(ctx, lastChunk...)
 		require.NoError(t, err)
@@ -182,21 +192,20 @@ func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
 		// head is not advanced due to a gap.
 		head, err := store.Head(ctx)
 		require.NoError(t, err)
+		assert.Equal(t, head.Height(), wantHead.Height())
+		t.Log("head", head.Height(), head.Hash())
 		assert.Equal(t, head.Hash(), wantHead.Hash())
 	}
-
-	{
-
-		err := store.Append(ctx, missedChunk...)
-		require.NoError(t, err)
-		// wait for batch to be written.
-		time.Sleep(100 * time.Millisecond)
-
-		// after appending missing headers we're on the latest header.
-		head, err := store.Head(ctx)
-		require.NoError(t, err)
-		assert.Equal(t, head.Hash(), latestHead.Hash())
-	}
+	// {
+	// 	err := store.Append(ctx, missedChunk...)
+	// 	require.NoError(t, err)
+	// 	// wait for batch to be written.
+	// 	time.Sleep(100 * time.Millisecond)
+	// 	// after appending missing headers we're on the latest header.
+	// 	head, err := store.Head(ctx)
+	// 	require.NoError(t, err)
+	// 	assert.Equal(t, head.Hash(), latestHead.Hash())
+	// }
 }
 
 // TestStore_GetRange tests possible combinations of requests and ensures that

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -182,6 +182,10 @@ func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
 		head, err := store.Head(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, head.Hash(), wantHead.Hash())
+
+		// check that store height is aligned with the head.
+		height := store.Height()
+		assert.Equal(t, height, head.Height())
 	}
 	{
 		err := store.Append(ctx, lastChunk...)
@@ -195,6 +199,10 @@ func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
 		assert.Equal(t, head.Height(), wantHead.Height())
 		t.Log("head", head.Height(), head.Hash())
 		assert.Equal(t, head.Hash(), wantHead.Hash())
+
+		// check that store height is aligned with the head.
+		height := store.Height()
+		assert.Equal(t, height, head.Height())
 	}
 	{
 		err := store.Append(ctx, missedChunk...)
@@ -206,6 +214,10 @@ func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
 		head, err := store.Head(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, head.Hash(), latestHead.Hash())
+
+		// check that store height is aligned with the head.
+		height := store.Height()
+		assert.Equal(t, height, head.Height())
 	}
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -190,6 +190,7 @@ func TestStore_Append(t *testing.T) {
 
 	head, err = store.Head(ctx)
 	assert.NoError(t, err)
+	assert.Equal(t, head.Height(), headers[len(headers)-1].Height())
 	assert.Equal(t, head.Hash(), headers[len(headers)-1].Hash())
 }
 
@@ -222,6 +223,7 @@ func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
 		// head is advanced to the last known header.
 		head, err := store.Head(ctx)
 		require.NoError(t, err)
+		assert.Equal(t, head.Height(), wantHead.Height())
 		assert.Equal(t, head.Hash(), wantHead.Hash())
 
 		// check that store height is aligned with the head.
@@ -253,6 +255,7 @@ func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
 		// after appending missing headers we're on the latest header.
 		head, err := store.Head(ctx)
 		require.NoError(t, err)
+		assert.Equal(t, head.Height(), latestHead.Height())
 		assert.Equal(t, head.Hash(), latestHead.Hash())
 
 		// check that store height is aligned with the head.

--- a/sync/sync_head_test.go
+++ b/sync/sync_head_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -121,13 +122,11 @@ func (t *wrappedGetter) Head(ctx context.Context, options ...header.HeadOption[*
 }
 
 func (t *wrappedGetter) Get(ctx context.Context, hash header.Hash) (*headertest.DummyHeader, error) {
-	// TODO implement me
-	panic("implement me")
+	return nil, errors.New("implement me")
 }
 
 func (t *wrappedGetter) GetByHeight(ctx context.Context, u uint64) (*headertest.DummyHeader, error) {
-	// TODO implement me
-	panic("implement me")
+	return nil, errors.New("implement me")
 }
 
 func (t *wrappedGetter) GetRangeByHeight(
@@ -135,6 +134,5 @@ func (t *wrappedGetter) GetRangeByHeight(
 	from *headertest.DummyHeader,
 	to uint64,
 ) ([]*headertest.DummyHeader, error) {
-	// TODO implement me
-	panic("implement me")
+	return nil, errors.New("implement me")
 }


### PR DESCRIPTION
## Overview

The main idea of this PR is to make `Store[H].Head` working properly, to be precise: returning head that was written to the disk (*). Along with that `heightSub.height` is increased monotonically to prevent bugs when we have store appends out of order.

To test everything I'm adding 2 new tests: one that verifies out of order appends and another when which does this concurrently. Which helped to find 2 or even 3 edge cases during coding.

Fixes #201