### PR TITLE
feat(store): flush loop retries and backoff

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -408,7 +408,7 @@ func (s *Store[H]) flushLoop() {
 
 			from, to := toFlush[0].Height(), toFlush[len(toFlush)-1].Height()
 			if i == flushRetries {
-				log.Fatalw("writing header batch", "from", from, "to", to, "err", err)
+				log.Errorw("writing header batch", "from", from, "to", to, "err", err)
 				os.Exit(1)
 				return
 			}


### PR DESCRIPTION
## Overview

Before this PR when we fail to write a batch we just ignore it. Adding retries + backoff to try a few times.

Fixes #209 