### PR TITLE
feat(store): add readTail method

### DIFF
--- a/store/keys.go
+++ b/store/keys.go
@@ -8,7 +8,10 @@ import (
 	"github.com/celestiaorg/go-header"
 )
 
-var headKey = datastore.NewKey("head")
+var (
+	headKey = datastore.NewKey("head")
+	tailKey = datastore.NewKey("tail")
+)
 
 func heightKey(h uint64) datastore.Key {
 	return datastore.NewKey(strconv.Itoa(int(h)))

--- a/store/store.go
+++ b/store/store.go
@@ -482,6 +482,22 @@ func (s *Store[H]) readHead(ctx context.Context) (H, error) {
 	return s.Get(ctx, head)
 }
 
+// readTail loads the tail from the datastore.
+func (s *Store[H]) readTail(ctx context.Context) (H, error) {
+	var zero H
+	b, err := s.ds.Get(ctx, tailKey)
+	if err != nil {
+		return zero, err
+	}
+
+	var tail header.Hash
+	if err := tail.UnmarshalJSON(b); err != nil {
+		return zero, err
+	}
+
+	return s.Get(ctx, tail)
+}
+
 func (s *Store[H]) get(ctx context.Context, hash header.Hash) ([]byte, error) {
 	startTime := time.Now()
 	data, err := s.ds.Get(ctx, datastore.NewKey(hash.String()))


### PR DESCRIPTION
## Overview

Adding method that will return tail header from the underlying datastore when `Store[H]` will be started. Similar to `readHead` method in `Store[H]`.

Should be merged after #210 