### PR TITLE
"readability"fix(store): Clearer range check

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -277,10 +277,8 @@ func (s *Store[H]) GetRange(ctx context.Context, from, to uint64) ([]H, error) {
 }
 
 func (s *Store[H]) getRangeByHeight(ctx context.Context, from, to uint64) ([]H, error) {
-	// as the requested range is non-inclusive in the end[from;to), we need to compare
-	// `from` with `to-1`
-	if from > to-1 {
-		return nil, fmt.Errorf("header/store: invalid range(%d,%d)", from, to-1)
+	if from >= to {
+		return nil, fmt.Errorf("header/store: invalid range(%d,%d)", from, to)
 	}
 	h, err := s.GetByHeight(ctx, to-1)
 	if err != nil {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -93,6 +93,10 @@ func TestStore(t *testing.T) {
 	out, err = store.getRangeByHeight(ctx, 1, 13)
 	require.NoError(t, err)
 	assert.Len(t, out, 12)
+
+	out, err = store.getRangeByHeight(ctx, 10, 11)
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
 }
 
 // TestStore_GetRangeByHeight_ExpectedRange


### PR DESCRIPTION
This PR cleans up a sanity check on the range request in the private method of store to make it more readable. 