### PR TITLE
fix: keep peer for io deadline or connect failed error

### DIFF
--- a/p2p/session.go
+++ b/p2p/session.go
@@ -217,7 +217,7 @@ func (s *session[H]) doRequest(
 		// ErrNotFound is not a critical error here. It means
 		// that peer hasn't synced the requested range yet.
 		// Returning peer to the queue, so it could serve another ranges.
-		if errors.Is(err, header.ErrNotFound) {
+		if errors.Is(err, header.ErrNotFound) || errors.Is(err, errEmptyResponse) {
 			s.queue.push(stat)
 		}
 		return


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

if network is really bad,  there will be many io deadline error. and peerQuene will push back the peerStat,  go-header will lost the peer for ever.   this pr push back the peerStat when response is empty