### PR TITLE
fix(store): track store's contiguous head

### DIFF
--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -17,6 +17,7 @@ func TestExchangeServer_handleRequestTimeout(t *testing.T) {
 	peer := createMocknet(t, 1)
 	s, err := store.NewStore[*headertest.DummyHeader](datastore.NewMapDatastore())
 	require.NoError(t, err)
+	s.Init(context.Background(), headertest.RandDummyHeader(t))
 	server, err := NewExchangeServer[*headertest.DummyHeader](
 		peer[0],
 		s,

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -17,7 +17,9 @@ func TestExchangeServer_handleRequestTimeout(t *testing.T) {
 	peer := createMocknet(t, 1)
 	s, err := store.NewStore[*headertest.DummyHeader](datastore.NewMapDatastore())
 	require.NoError(t, err)
-	s.Init(context.Background(), headertest.RandDummyHeader(t))
+	head := headertest.RandDummyHeader(t)
+	head.HeightI %= 1000 // make it a bit lower
+	s.Init(context.Background(), head)
 	server, err := NewExchangeServer[*headertest.DummyHeader](
 		peer[0],
 		s,

--- a/store/batch.go
+++ b/store/batch.go
@@ -76,7 +76,11 @@ func (b *batch[H]) getByHeight(height uint64) H {
 		return zero
 	}
 
-	return b.headers[height-base-1]
+	h := b.headers[height-base-1]
+	if h.Height() == height {
+		return h
+	}
+	return zero
 }
 
 // Append appends new headers to the batch.

--- a/store/batch.go
+++ b/store/batch.go
@@ -6,7 +6,7 @@ import (
 	"github.com/celestiaorg/go-header"
 )
 
-// batch keeps an adjacent range of headers and loosely mimics the Store
+// batch keeps a range of headers and loosely mimics the Store
 // interface. NOTE: Can fully implement Store for a use case.
 //
 // It keeps a mapping 'height -> header' and 'hash -> height'

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -64,7 +64,7 @@ func (hs *heightSub) SetHeight(height uint64) {
 		}
 
 		hs.heightSubsLk.Lock()
-		defer hs.heightSubsLk.Unlock() //nolint:gocritic we have a return below
+		defer hs.heightSubsLk.Unlock() //nolint:gocritic // we have a return below
 
 		for ; curr <= height; curr++ {
 			hs.notify(curr, true)

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -102,7 +102,6 @@ func (hs *heightSub[H]) Pub(headers ...H) {
 	if from > to {
 		panic(fmt.Sprintf("from must be lower than to, have: %d and %d", from, to))
 	}
-	hs.SetHeight(to)
 
 	hs.heightReqsLk.Lock()
 	defer hs.heightReqsLk.Unlock()

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -114,11 +114,13 @@ func (hs *heightSub) Wait(ctx context.Context, height uint64) error {
 
 // Notify and release the waiters in [Wait].
 // Note: do not advance heightSub's height.
-func (hs *heightSub) Notify(height uint64) {
+func (hs *heightSub) Notify(heights ...uint64) {
 	hs.heightSubsLk.Lock()
 	defer hs.heightSubsLk.Unlock()
 
-	hs.notify(height, true)
+	for _, h := range heights {
+		hs.notify(h, true)
+	}
 }
 
 func (hs *heightSub) notify(height uint64, all bool) {

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -34,7 +34,7 @@ func newHeightSub[H header.Header[H]]() *heightSub[H] {
 }
 
 // Init the heightSub with a given height.
-// Notifies all awaiting [Wait] calls lower than height.
+// Notifies all awaiting [WaitHeight] calls lower than height.
 func (hs *heightSub[H]) Init(height uint64) {
 	hs.height.Store(height)
 
@@ -54,7 +54,7 @@ func (hs *heightSub[H]) Height() uint64 {
 }
 
 // SetHeight sets the new head height for heightSub.
-// Notifies all awaiting [Wait] calls in range from [heightSub.Height] to height.
+// Notifies all awaiting [WaitHeight] calls in range from [heightSub.Height] to height.
 func (hs *heightSub[H]) SetHeight(height uint64) {
 	for {
 		curr := hs.height.Load()
@@ -75,10 +75,10 @@ func (hs *heightSub[H]) SetHeight(height uint64) {
 	}
 }
 
-// Wait for a given height to be published.
+// WaitHeight for a given height to be published.
 // It can return errElapsedHeight, which means a requested height was already seen
 // and caller should get it elsewhere.
-func (hs *heightSub[H]) Wait(ctx context.Context, height uint64) error {
+func (hs *heightSub[H]) WaitHeight(ctx context.Context, height uint64) error {
 	if hs.Height() >= height {
 		return errElapsedHeight
 	}
@@ -114,7 +114,7 @@ func (hs *heightSub[H]) Wait(ctx context.Context, height uint64) error {
 	}
 }
 
-// NotifyHeight and release the waiters in [Wait].
+// NotifyHeight and release the waiters in [WaitHeight].
 // Note: do not advance heightSub's height.
 func (hs *heightSub[H]) NotifyHeight(height uint64) {
 	hs.heightSubsLk.Lock()

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -18,10 +18,10 @@ type heightSub[H header.Header[H]] struct {
 	// that has been fully verified and inserted into the subjective chain
 	height       atomic.Uint64
 	heightSubsLk sync.Mutex
-	heightSubs   map[uint64]*signalAndCounter
+	heightSubs   map[uint64]*sub
 }
 
-type signalAndCounter struct {
+type sub struct {
 	signal chan struct{}
 	count  int
 }
@@ -29,7 +29,7 @@ type signalAndCounter struct {
 // newHeightSub instantiates new heightSub.
 func newHeightSub[H header.Header[H]]() *heightSub[H] {
 	return &heightSub[H]{
-		heightSubs: make(map[uint64]*signalAndCounter),
+		heightSubs: make(map[uint64]*sub),
 	}
 }
 
@@ -94,7 +94,7 @@ func (hs *heightSub[H]) Wait(ctx context.Context, height uint64) error {
 
 	sac, ok := hs.heightSubs[height]
 	if !ok {
-		sac = &signalAndCounter{
+		sac = &sub{
 			signal: make(chan struct{}, 1),
 		}
 		hs.heightSubs[height] = sac

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -42,7 +42,6 @@ func (hs *heightSub[H]) SetHeight(height uint64) {
 			return
 		}
 		if hs.height.CompareAndSwap(curr, height) {
-			println("CAS", curr, height)
 			hs.heightReqsLk.Lock()
 			for ; curr <= height; curr++ {
 				reqs, ok := hs.heightReqs[curr]

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -34,6 +34,7 @@ func (hs *heightSub[H]) Height() uint64 {
 }
 
 // SetHeight sets the new head height for heightSub.
+// Unblocks all awaiting [Wait] calls in range from [heightSub.Height] to height.
 func (hs *heightSub[H]) SetHeight(height uint64) {
 	for {
 		curr := hs.height.Load()

--- a/store/heightsub.go
+++ b/store/heightsub.go
@@ -33,6 +33,21 @@ func newHeightSub[H header.Header[H]]() *heightSub[H] {
 	}
 }
 
+// Init the heightSub with a given height.
+// Unblocks all awaiting [Wait] calls lower than height.
+func (hs *heightSub[H]) Init(height uint64) {
+	hs.height.Store(height)
+
+	hs.heightSubsLk.Lock()
+	defer hs.heightSubsLk.Unlock()
+
+	for h := range hs.heightSubs {
+		if h < height {
+			hs.unblockHeight(h, true)
+		}
+	}
+}
+
 // Height reports current height.
 func (hs *heightSub[H]) Height() uint64 {
 	return hs.height.Load()

--- a/store/heightsub_test.go
+++ b/store/heightsub_test.go
@@ -104,7 +104,7 @@ func TestHeightSub_withWaitCancelled(t *testing.T) {
 }
 
 // Test heightSub can accept non-adj headers without an error.
-func TestHeightSubNonAdjacement(t *testing.T) {
+func TestHeightSubNonAdjacency(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 

--- a/store/heightsub_test.go
+++ b/store/heightsub_test.go
@@ -20,7 +20,7 @@ func TestHeightSub(t *testing.T) {
 	{
 		hs.Init(99)
 
-		err := hs.Wait(ctx, 10)
+		err := hs.WaitHeight(ctx, 10)
 		assert.ErrorIs(t, err, errElapsedHeight)
 	}
 
@@ -33,7 +33,7 @@ func TestHeightSub(t *testing.T) {
 			hs.SetHeight(102)
 		}()
 
-		err := hs.Wait(ctx, 101)
+		err := hs.WaitHeight(ctx, 101)
 		assert.NoError(t, err)
 	}
 
@@ -42,7 +42,7 @@ func TestHeightSub(t *testing.T) {
 		ch := make(chan error, 10)
 		for range cap(ch) {
 			go func() {
-				err := hs.Wait(ctx, 103)
+				err := hs.WaitHeight(ctx, 103)
 				ch <- err
 			}()
 		}
@@ -76,7 +76,7 @@ func TestHeightSub_withWaitCancelled(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, time.Duration(i+1)*time.Millisecond)
 			defer cancel()
 
-			err := hs.Wait(ctx, 100)
+			err := hs.WaitHeight(ctx, 100)
 			cancelChs[i] <- err
 		}()
 
@@ -84,7 +84,7 @@ func TestHeightSub_withWaitCancelled(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second)
 			defer cancel()
 
-			err := hs.Wait(ctx, 100)
+			err := hs.WaitHeight(ctx, 100)
 			blockedChs[i] <- err
 		}()
 	}
@@ -118,7 +118,7 @@ func TestHeightSubNonAdjacement(t *testing.T) {
 		hs.SetHeight(300)
 	}()
 
-	err := hs.Wait(ctx, 200)
+	err := hs.WaitHeight(ctx, 200)
 	assert.NoError(t, err)
 }
 
@@ -147,7 +147,7 @@ func TestHeightSubCancellation(t *testing.T) {
 	sub := make(chan struct{})
 	go func() {
 		// subscribe first time
-		hs.Wait(ctx, h.Height())
+		hs.WaitHeight(ctx, h.Height())
 		sub <- struct{}{}
 	}()
 
@@ -157,7 +157,7 @@ func TestHeightSubCancellation(t *testing.T) {
 	// subscribe again but with failed canceled context
 	canceledCtx, cancel := context.WithCancel(ctx)
 	cancel()
-	err := hs.Wait(canceledCtx, h.Height())
+	err := hs.WaitHeight(canceledCtx, h.Height())
 	assert.ErrorIs(t, err, context.Canceled)
 
 	// update height

--- a/store/heightsub_test.go
+++ b/store/heightsub_test.go
@@ -68,6 +68,68 @@ func TestHeightSub(t *testing.T) {
 	}
 }
 
+// Test heightSub can accept non-adj headers without an error.
+func TestHeightSubNonAdjacement(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	hs := newHeightSub[*headertest.DummyHeader]()
+
+	{
+		h := headertest.RandDummyHeader(t)
+		h.HeightI = 100
+		hs.SetHeight(99)
+		hs.Pub(h)
+	}
+
+	{
+		go func() {
+			// fixes flakiness on CI
+			time.Sleep(time.Millisecond)
+
+			h1 := headertest.RandDummyHeader(t)
+			h1.HeightI = 200
+			h2 := headertest.RandDummyHeader(t)
+			h2.HeightI = 300
+			hs.Pub(h1, h2)
+		}()
+
+		h, err := hs.Sub(ctx, 200)
+		assert.NoError(t, err)
+		assert.NotNil(t, h)
+	}
+}
+
+// Test heightSub's height cannot go down but only up.
+func TestHeightSub_monotonicHeight(t *testing.T) {
+	hs := newHeightSub[*headertest.DummyHeader]()
+
+	{
+		h := headertest.RandDummyHeader(t)
+		h.HeightI = 100
+		hs.SetHeight(99)
+		hs.Pub(h)
+	}
+
+	{
+		h1 := headertest.RandDummyHeader(t)
+		h1.HeightI = 200
+		h2 := headertest.RandDummyHeader(t)
+		h2.HeightI = 300
+		hs.Pub(h1, h2)
+	}
+
+	{
+		h1 := headertest.RandDummyHeader(t)
+		h1.HeightI = 120
+		h2 := headertest.RandDummyHeader(t)
+		h2.HeightI = 130
+		hs.Pub(h1, h2)
+	}
+
+	assert.Equal(t, hs.height.Load(), uint64(300))
+}
+
 func TestHeightSubCancellation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/store/heightsub_test.go
+++ b/store/heightsub_test.go
@@ -18,7 +18,7 @@ func TestHeightSub(t *testing.T) {
 
 	// assert subscription returns nil for past heights
 	{
-		hs.SetHeight(99)
+		hs.Init(99)
 
 		err := hs.Wait(ctx, 10)
 		assert.ErrorIs(t, err, errElapsedHeight)
@@ -62,7 +62,7 @@ func TestHeightSub_withWaitCancelled(t *testing.T) {
 	defer cancel()
 
 	hs := newHeightSub[*headertest.DummyHeader]()
-	hs.SetHeight(10)
+	hs.Init(10)
 
 	const waiters = 5
 
@@ -109,8 +109,7 @@ func TestHeightSubNonAdjacement(t *testing.T) {
 	defer cancel()
 
 	hs := newHeightSub[*headertest.DummyHeader]()
-
-	hs.SetHeight(99)
+	hs.Init(99)
 
 	go func() {
 		// fixes flakiness on CI
@@ -127,7 +126,7 @@ func TestHeightSubNonAdjacement(t *testing.T) {
 func TestHeightSub_monotonicHeight(t *testing.T) {
 	hs := newHeightSub[*headertest.DummyHeader]()
 
-	hs.SetHeight(99)
+	hs.Init(99)
 	assert.Equal(t, int64(hs.height.Load()), int64(99))
 
 	hs.SetHeight(300)

--- a/store/heightsub_test.go
+++ b/store/heightsub_test.go
@@ -104,30 +104,14 @@ func TestHeightSubNonAdjacement(t *testing.T) {
 func TestHeightSub_monotonicHeight(t *testing.T) {
 	hs := newHeightSub[*headertest.DummyHeader]()
 
-	{
-		h := headertest.RandDummyHeader(t)
-		h.HeightI = 100
-		hs.SetHeight(99)
-		hs.Pub(h)
-	}
+	hs.SetHeight(99)
+	assert.Equal(t, int64(hs.height.Load()), int64(99))
 
-	{
-		h1 := headertest.RandDummyHeader(t)
-		h1.HeightI = 200
-		h2 := headertest.RandDummyHeader(t)
-		h2.HeightI = 300
-		hs.Pub(h1, h2)
-	}
+	hs.SetHeight(300)
+	assert.Equal(t, int64(hs.height.Load()), int64(300))
 
-	{
-		h1 := headertest.RandDummyHeader(t)
-		h1.HeightI = 120
-		h2 := headertest.RandDummyHeader(t)
-		h2.HeightI = 130
-		hs.Pub(h1, h2)
-	}
-
-	assert.Equal(t, hs.height.Load(), uint64(300))
+	hs.SetHeight(120)
+	assert.Equal(t, int64(hs.height.Load()), int64(300))
 }
 
 func TestHeightSubCancellation(t *testing.T) {

--- a/store/heightsub_test.go
+++ b/store/heightsub_test.go
@@ -98,7 +98,7 @@ func TestHeightSubCancellation(t *testing.T) {
 	defer cancel()
 
 	h := headertest.RandDummyHeader(t)
-	h.HeightI %= 100 // make it a bit lower
+	h.HeightI %= 1000 // make it a bit lower
 	hs := newHeightSub[*headertest.DummyHeader]()
 
 	sub := make(chan struct{})

--- a/store/heightsub_test.go
+++ b/store/heightsub_test.go
@@ -42,16 +42,14 @@ func TestHeightSub(t *testing.T) {
 		ch := make(chan error, 10)
 		for range cap(ch) {
 			go func() {
-				_, err := hs.Sub(ctx, 103)
+				err := hs.Wait(ctx, 103)
 				ch <- err
 			}()
 		}
 
 		time.Sleep(time.Millisecond * 10)
 
-		h3 := headertest.RandDummyHeader(t)
-		h3.HeightI = 103
-		hs.Pub(h3)
+		hs.SetHeight(103)
 
 		for range cap(ch) {
 			assert.NoError(t, <-ch)

--- a/store/metrics.go
+++ b/store/metrics.go
@@ -13,9 +13,7 @@ import (
 var meter = otel.Meter("header/store")
 
 type metrics struct {
-	headHeight           atomic.Int64
-	contiguousHeadHeight atomic.Int64
-
+	headHeight     atomic.Int64
 	headHeightInst metric.Int64ObservableGauge
 	headHeightReg  metric.Registration
 
@@ -65,12 +63,6 @@ func newMetrics() (m *metrics, err error) {
 func (m *metrics) newHead(height uint64) {
 	m.observe(context.Background(), func(ctx context.Context) {
 		m.headHeight.Store(int64(height))
-	})
-}
-
-func (m *metrics) newContiguousHead(height uint64) {
-	m.observe(context.Background(), func(ctx context.Context) {
-		m.contiguousHeadHeight.Store(int64(height))
 	})
 }
 

--- a/store/metrics.go
+++ b/store/metrics.go
@@ -13,7 +13,9 @@ import (
 var meter = otel.Meter("header/store")
 
 type metrics struct {
-	headHeight     atomic.Int64
+	headHeight           atomic.Int64
+	contiguousHeadHeight atomic.Int64
+
 	headHeightInst metric.Int64ObservableGauge
 	headHeightReg  metric.Registration
 
@@ -63,6 +65,12 @@ func newMetrics() (m *metrics, err error) {
 func (m *metrics) newHead(height uint64) {
 	m.observe(context.Background(), func(ctx context.Context) {
 		m.headHeight.Store(int64(height))
+	})
+}
+
+func (m *metrics) newContiguousHead(height uint64) {
+	m.observe(context.Background(), func(ctx context.Context) {
+		m.contiguousHeadHeight.Store(int64(height))
 	})
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -518,10 +518,7 @@ func (s *Store[H]) notifyAndAdvance(ctx context.Context, headers ...H) {
 	}
 	s.heightSub.Notify(heights...)
 
-	currHead := s.contiguousHead.Load()
-	if currHead != nil {
-		s.advanceContiguousHead(ctx, s.heightSub.Height())
-	}
+	s.advanceContiguousHead(ctx, s.heightSub.Height())
 }
 
 // advanceContiguousHead return a new highest contiguous height

--- a/store/store.go
+++ b/store/store.go
@@ -379,7 +379,7 @@ func (s *Store[H]) flushLoop() {
 		s.pending.Append(headers...)
 		// notify waiters in heightSub and advance contiguousHead
 		// if we don't have gaps.
-		s.unblockAndAdvance(ctx, headers...)
+		s.notifyAndAdvance(ctx, headers...)
 		// don't flush and continue if pending batch is not grown enough,
 		// and Store is not stopping(headers == nil)
 		if s.pending.Len() < s.Params.WriteBatchSize && headers != nil {
@@ -506,12 +506,12 @@ func (s *Store[H]) get(ctx context.Context, hash header.Hash) ([]byte, error) {
 	return data, nil
 }
 
-// unblockAndAdvance will notify waiters in heightSub and advance contiguousHead
+// notifyAndAdvance will notify waiters in heightSub and advance contiguousHead
 // based on already written headers.
-func (s *Store[H]) unblockAndAdvance(ctx context.Context, headers ...H) {
+func (s *Store[H]) notifyAndAdvance(ctx context.Context, headers ...H) {
 	// always inform heightSub about new headers seen
 	for _, h := range headers {
-		s.heightSub.UnblockHeight(h.Height())
+		s.heightSub.NotifyHeight(h.Height())
 	}
 
 	currHead := s.contiguousHead.Load()

--- a/store/store.go
+++ b/store/store.go
@@ -520,7 +520,8 @@ func (s *Store[H]) advanceContiguousHead(ctx context.Context, height uint64) {
 	s.metrics.newHead(newHead.Height())
 }
 
-// nextContiguousHead returns a next contiguous header if any.
+// nextContiguousHead iterates up header by header until it finds a gap.
+// if height+1 header not found returns a default header.
 func (s *Store[H]) nextContiguousHead(ctx context.Context, height uint64) H {
 	var newHead H
 	for {

--- a/store/store.go
+++ b/store/store.go
@@ -231,12 +231,12 @@ func (s *Store[H]) GetByHeight(ctx context.Context, height uint64) (H, error) {
 		return zero, errors.New("header/store: height must be bigger than zero")
 	}
 
-	// switch h, err := s.getByHeight(ctx, height); {
-	// case err == nil:
-	// 	return h, nil
-	// case ctx.Err() != nil:
-	// 	return zero, ctx.Err()
-	// }
+	switch h, err := s.getByHeight(ctx, height); {
+	case err == nil:
+		return h, nil
+	case ctx.Err() != nil:
+		return zero, ctx.Err()
+	}
 
 	// if the requested 'height' was not yet published
 	// we subscribe to it

--- a/store/store.go
+++ b/store/store.go
@@ -539,7 +539,7 @@ func (s *Store[H]) advanceContiguousHead(ctx context.Context, headers ...H) {
 
 func (s *Store[H]) updateContiguousHead(newHead H, newHeight uint64) {
 	s.contiguousHead.Store(&newHead)
-	s.heightSub.UnblockHeight(newHeight)
+	s.heightSub.SetHeight(newHeight)
 	log.Infow("new head", "height", newHead.Height(), "hash", newHead.Hash())
 	s.metrics.newHead(newHead.Height())
 

--- a/store/store.go
+++ b/store/store.go
@@ -376,6 +376,9 @@ func (s *Store[H]) Append(ctx context.Context, headers ...H) error {
 // (1) Appends not to be blocked on long disk IO writes and underlying DB compactions
 // (2) Batching header writes
 func (s *Store[H]) flushLoop() {
+	// advance based on what we have on disk.
+	s.doAdvanceContiguousHead(context.Background(), s.Height())
+
 	defer close(s.writesDn)
 	ctx := context.Background()
 	for headers := range s.writes {
@@ -383,7 +386,7 @@ func (s *Store[H]) flushLoop() {
 		s.pending.Append(headers...)
 		// try to advance contiguousHead if we don't have gaps.
 		// and notify waiters in heightSub.
-		s.advanceContiguousHead(ctx, headers...)
+		s.tryAdvanceContiguousHead(ctx, headers...)
 		// don't flush and continue if pending batch is not grown enough,
 		// and Store is not stopping(headers == nil)
 		if s.pending.Len() < s.Params.WriteBatchSize && headers != nil {
@@ -497,17 +500,19 @@ func (s *Store[H]) get(ctx context.Context, hash header.Hash) ([]byte, error) {
 }
 
 // try advance contiguous head based on already written headers.
-func (s *Store[H]) advanceContiguousHead(ctx context.Context, headers ...H) {
+func (s *Store[H]) tryAdvanceContiguousHead(ctx context.Context, headers ...H) {
 	// always inform heightSub about new headers seen
 	for _, h := range headers {
 		s.heightSub.UnblockHeight(h.Height())
 	}
 
 	currHead := s.contiguousHead.Load()
-	if currHead == nil {
-		return
+	if currHead != nil {
+		s.doAdvanceContiguousHead(ctx, (*currHead).Height())
 	}
-	currHeight := (*currHead).Height()
+}
+
+func (s *Store[H]) doAdvanceContiguousHead(ctx context.Context, currHeight uint64) {
 	prevHeight := currHeight
 
 	// TODO(cristaloleg): benchmark this timeout or make it dynamic.

--- a/store/store.go
+++ b/store/store.go
@@ -521,7 +521,7 @@ func (s *Store[H]) notifyAndAdvance(ctx context.Context, headers ...H) {
 }
 
 // advanceContiguousHead return a new highest contiguous height
-// or a given if not found.
+// or returns a given height if not found.
 func (s *Store[H]) advanceContiguousHead(ctx context.Context, currHeight uint64) uint64 {
 	// TODO(cristaloleg): benchmark this timeout or make it dynamic.
 	advCtx, advCancel := context.WithTimeout(ctx, 10*time.Second)
@@ -557,11 +557,13 @@ func (s *Store[H]) updateContiguousHead(ctx context.Context, newHead H) {
 	if err != nil {
 		log.Errorw("cannot marshal new head",
 			"height", newHead.Height(), "hash", newHead.Hash(), "err", err)
+		return
 	}
 
 	if err := s.ds.Put(ctx, headKey, b); err != nil {
 		log.Errorw("cannot put new head",
 			"height", newHead.Height(), "hash", newHead.Hash(), "err", err)
+		return
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -518,12 +518,12 @@ func (s *Store[H]) advanceContiguousHead(ctx context.Context) {
 	prevHeight := currHeight
 
 	// TODO(cristaloleg): benchmark this timeout or make it dynamic.
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
+	advCtx, advCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer advCancel()
 
 	var newHead H
 	for {
-		h, err := s.getByHeight(ctx, currHeight+1)
+		h, err := s.getByHeight(advCtx, currHeight+1)
 		if err != nil {
 			break
 		}
@@ -537,7 +537,7 @@ func (s *Store[H]) advanceContiguousHead(ctx context.Context) {
 		log.Infow("new head", "height", newHead.Height(), "hash", newHead.Hash())
 		s.metrics.newHead(newHead.Height())
 
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		b, err := newHead.Hash().MarshalJSON()

--- a/store/store.go
+++ b/store/store.go
@@ -123,7 +123,7 @@ func (s *Store[H]) Init(ctx context.Context, initial H) error {
 
 	log.Infow("initialized head", "height", initial.Height(), "hash", initial.Hash())
 	s.contiguousHead.Store(&initial)
-	s.heightSub.SetHeight(initial.Height())
+	s.heightSub.Init(initial.Height())
 	return nil
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -179,6 +179,10 @@ func (s *Store[H]) Height() uint64 {
 }
 
 func (s *Store[H]) Head(ctx context.Context, _ ...header.HeadOption[H]) (H, error) {
+	if head := s.contiguousHead.Load(); head != nil {
+		return *head, nil
+	}
+
 	head, err := s.GetByHeight(ctx, s.heightSub.Height())
 	if err == nil {
 		return head, nil

--- a/store/store.go
+++ b/store/store.go
@@ -466,11 +466,7 @@ func (s *Store[H]) loadHeadKey(ctx context.Context) error {
 		return err
 	}
 
-	newHeight := s.advanceContiguousHead(ctx, h.Height())
-	if newHeight >= h.Height() {
-		s.contiguousHead.Store(&h)
-		s.heightSub.SetHeight(h.Height())
-	}
+	s.advanceContiguousHead(ctx, h.Height())
 	return nil
 }
 
@@ -521,8 +517,8 @@ func (s *Store[H]) notifyAndAdvance(ctx context.Context, headers ...H) {
 }
 
 // advanceContiguousHead return a new highest contiguous height
-// or returns a given height if not found.
-func (s *Store[H]) advanceContiguousHead(ctx context.Context, currHeight uint64) uint64 {
+// or returns the given height if not found.
+func (s *Store[H]) advanceContiguousHead(ctx context.Context, currHeight uint64) {
 	// TODO(cristaloleg): benchmark this timeout or make it dynamic.
 	advCtx, advCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer advCancel()
@@ -538,10 +534,9 @@ func (s *Store[H]) advanceContiguousHead(ctx context.Context, currHeight uint64)
 		currHeight++
 	}
 
-	if currHeight > prevHeight {
+	if currHeight >= prevHeight {
 		s.updateContiguousHead(ctx, newHead)
 	}
-	return currHeight
 }
 
 func (s *Store[H]) updateContiguousHead(ctx context.Context, newHead H) {

--- a/store/store.go
+++ b/store/store.go
@@ -222,7 +222,7 @@ func (s *Store[H]) GetByHeight(ctx context.Context, height uint64) (H, error) {
 	// if the requested 'height' was not yet published
 	// we subscribe to it
 	if head := s.contiguousHead.Load(); head == nil || height > (*head).Height() {
-		err := s.heightSub.Wait(ctx, height)
+		err := s.heightSub.WaitHeight(ctx, height)
 		if err != nil && !errors.Is(err, errElapsedHeight) {
 			return zero, err
 		}

--- a/store/store.go
+++ b/store/store.go
@@ -231,6 +231,13 @@ func (s *Store[H]) GetByHeight(ctx context.Context, height uint64) (H, error) {
 		return zero, errors.New("header/store: height must be bigger than zero")
 	}
 
+	// switch h, err := s.getByHeight(ctx, height); {
+	// case err == nil:
+	// 	return h, nil
+	// case ctx.Err() != nil:
+	// 	return zero, ctx.Err()
+	// }
+
 	// if the requested 'height' was not yet published
 	// we subscribe to it
 	if head := s.contiguousHead.Load(); head == nil || height > (*head).Height() {
@@ -390,11 +397,8 @@ func (s *Store[H]) flushLoop() {
 	for headers := range s.writes {
 		// add headers to the pending and ensure they are accessible
 		s.pending.Append(headers...)
-		// and notify waiters if any + increase current read head height
-		// it is important to do Pub after updating pending
-		// so pending is consistent with atomic Height counter on the heightSub
-		// s.heightSub.Pub(headers...)
 		// try to advance contiguousHead if we don't have gaps.
+		// and notify waiters in heightSub.
 		s.advanceContiguousHead(ctx)
 		// don't flush and continue if pending batch is not grown enough,
 		// and Store is not stopping(headers == nil)

--- a/store/store.go
+++ b/store/store.go
@@ -539,14 +539,14 @@ func (s *Store[H]) advanceContiguousHead(ctx context.Context, currHeight uint64)
 	}
 
 	if currHeight > prevHeight {
-		s.updateContiguousHead(ctx, newHead, currHeight)
+		s.updateContiguousHead(ctx, newHead)
 	}
 	return currHeight
 }
 
-func (s *Store[H]) updateContiguousHead(ctx context.Context, newHead H, newHeight uint64) {
+func (s *Store[H]) updateContiguousHead(ctx context.Context, newHead H) {
 	s.contiguousHead.Store(&newHead)
-	s.heightSub.SetHeight(newHeight)
+	s.heightSub.SetHeight(newHead.Height())
 	log.Infow("new head", "height", newHead.Height(), "hash", newHead.Hash())
 	s.metrics.newHead(newHead.Height())
 

--- a/store/store.go
+++ b/store/store.go
@@ -231,6 +231,10 @@ func (s *Store[H]) GetByHeight(ctx context.Context, height uint64) (H, error) {
 		return zero, errors.New("header/store: height must be bigger than zero")
 	}
 
+	if h, err := s.getByHeight(ctx, height); err == nil || ctx.Err() != nil {
+		return h, err
+	}
+
 	// if the requested 'height' was not yet published
 	// we subscribe to it
 	if head := s.contiguousHead.Load(); head == nil || height > (*head).Height() {

--- a/store/store.go
+++ b/store/store.go
@@ -466,7 +466,11 @@ func (s *Store[H]) loadHeadKey(ctx context.Context) error {
 		return err
 	}
 
-	s.advanceContiguousHead(ctx, h.Height())
+	newHeight := s.advanceContiguousHead(ctx, h.Height())
+	if newHeight >= h.Height() {
+		s.contiguousHead.Store(&h)
+		s.heightSub.SetHeight(h.Height())
+	}
 	return nil
 }
 
@@ -518,7 +522,7 @@ func (s *Store[H]) notifyAndAdvance(ctx context.Context, headers ...H) {
 
 // advanceContiguousHead return a new highest contiguous height
 // or returns the given height if not found.
-func (s *Store[H]) advanceContiguousHead(ctx context.Context, currHeight uint64) {
+func (s *Store[H]) advanceContiguousHead(ctx context.Context, currHeight uint64) uint64 {
 	// TODO(cristaloleg): benchmark this timeout or make it dynamic.
 	advCtx, advCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer advCancel()
@@ -534,9 +538,10 @@ func (s *Store[H]) advanceContiguousHead(ctx context.Context, currHeight uint64)
 		currHeight++
 	}
 
-	if currHeight >= prevHeight {
+	if currHeight > prevHeight {
 		s.updateContiguousHead(ctx, newHead)
 	}
+	return currHeight
 }
 
 func (s *Store[H]) updateContiguousHead(ctx context.Context, newHead H) {

--- a/store/store.go
+++ b/store/store.go
@@ -178,7 +178,7 @@ func (s *Store[H]) Height() uint64 {
 	return s.heightSub.Height()
 }
 
-func (s *Store[H]) Head(ctx context.Context, _ ...header.HeadOption[H]) (H, error) {
+func (s *Store[H]) Head(_ context.Context, _ ...header.HeadOption[H]) (H, error) {
 	if head := s.contiguousHead.Load(); head != nil {
 		return *head, nil
 	}
@@ -324,7 +324,6 @@ func (s *Store[H]) Append(ctx context.Context, headers ...H) error {
 	// collect valid headers
 	verified := make([]H, 0, lh)
 	for i, h := range headers {
-
 		err = head.Verify(h)
 		if err != nil {
 			var verErr *header.VerifyError

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"math/rand"
+	stdsync "sync"
 	"testing"
 	"time"
 
@@ -143,6 +145,127 @@ func TestStore_Append_BadHeader(t *testing.T) {
 	in[0].VerifyFailure = true
 	err = store.Append(ctx, in...)
 	require.Error(t, err)
+}
+
+func TestStore_Append(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	store := NewTestStore(t, ctx, ds, suite.Head(), WithWriteBatchSize(4))
+
+	head, err := store.Head(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, head.Hash(), suite.Head().Hash())
+
+	const workers = 10
+	const chunk = 5
+	headers := suite.GenDummyHeaders(workers * chunk)
+
+	errCh := make(chan error, workers)
+	var wg stdsync.WaitGroup
+	wg.Add(workers)
+
+	for i := range workers {
+		go func() {
+			defer wg.Done()
+			// make every append happened in random order.
+			time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+
+			err := store.Append(ctx, headers[i*chunk:(i+1)*chunk]...)
+			errCh <- err
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		assert.NoError(t, err)
+	}
+
+	// wait for batch to be written.
+	time.Sleep(100 * time.Millisecond)
+
+	// assert.Eventually(t, func() bool {
+	head, err = store.Head(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, int(head.Height()), int(headers[len(headers)-1].Height()))
+
+	// 	return int(head.Height()) == int(headers[len(headers)-1].Height())
+	// }, time.Second, time.Millisecond)
+	assert.Equal(t, head.Hash(), headers[len(headers)-1].Hash())
+}
+
+func TestStore_Append_stableHeadWhenGaps(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	store := NewTestStore(t, ctx, ds, suite.Head(), WithWriteBatchSize(4))
+
+	head, err := store.Head(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, head.Hash(), suite.Head().Hash())
+
+	firstChunk := suite.GenDummyHeaders(5)
+	missedChunk := suite.GenDummyHeaders(5)
+	lastChunk := suite.GenDummyHeaders(5)
+
+	wantHead := firstChunk[len(firstChunk)-1]
+	latestHead := lastChunk[len(lastChunk)-1]
+
+	{
+		err := store.Append(ctx, firstChunk...)
+		require.NoError(t, err)
+		// wait for batch to be written.
+		time.Sleep(100 * time.Millisecond)
+
+		// head is advanced to the last known header.
+		head, err := store.Head(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, head.Height(), wantHead.Height())
+		assert.Equal(t, head.Hash(), wantHead.Hash())
+
+		// check that store height is aligned with the head.
+		height := store.Height()
+		assert.Equal(t, height, head.Height())
+	}
+	{
+		err := store.Append(ctx, lastChunk...)
+		require.NoError(t, err)
+		// wait for batch to be written.
+		time.Sleep(100 * time.Millisecond)
+
+		// head is not advanced due to a gap.
+		head, err := store.Head(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, head.Height(), wantHead.Height())
+		assert.Equal(t, head.Hash(), wantHead.Hash())
+
+		// check that store height is aligned with the head.
+		height := store.Height()
+		assert.Equal(t, height, head.Height())
+	}
+	{
+		err := store.Append(ctx, missedChunk...)
+		require.NoError(t, err)
+		// wait for batch to be written.
+		time.Sleep(time.Second)
+
+		// after appending missing headers we're on the latest header.
+		head, err := store.Head(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, head.Height(), latestHead.Height())
+		assert.Equal(t, head.Hash(), latestHead.Hash())
+
+		// check that store height is aligned with the head.
+		height := store.Height()
+		assert.Equal(t, height, head.Height())
+	}
 }
 
 // TestStore_GetRange tests possible combinations of requests and ensures that

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -284,6 +284,7 @@ func TestStoreGetByHeight_whenGaps(t *testing.T) {
 	firstChunk := suite.GenDummyHeaders(5)
 	missedChunk := suite.GenDummyHeaders(5)
 	lastChunk := suite.GenDummyHeaders(5)
+	wantHead := lastChunk[len(lastChunk)-1]
 
 	{
 		latestHead := firstChunk[len(firstChunk)-1]
@@ -301,8 +302,6 @@ func TestStoreGetByHeight_whenGaps(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		wantHead := lastChunk[len(lastChunk)-1]
-
 		shortCtx, shortCancel := context.WithTimeout(ctx, 3*time.Second)
 		defer shortCancel()
 
@@ -339,6 +338,10 @@ func TestStoreGetByHeight_whenGaps(t *testing.T) {
 	select {
 	case err := <-errCh:
 		require.NoError(t, err)
+
+		head, err := store.GetByHeight(ctx, wantHead.Height())
+		require.NoError(t, err)
+		require.Equal(t, head, wantHead)
 	default:
 		t.Fatal("store.GetByHeight must not be blocked")
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/celestiaorg/go-header"
 	"github.com/celestiaorg/go-header/headertest"
 )
 
@@ -482,6 +483,7 @@ func TestBatch_GetByHeightBeforeInit(t *testing.T) {
 	t.Cleanup(cancel)
 
 	suite := headertest.NewTestSuite(t)
+	suite.Head().HeightI = 1_000_000
 
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	store, err := NewStore[*headertest.DummyHeader](ds)
@@ -494,9 +496,8 @@ func TestBatch_GetByHeightBeforeInit(t *testing.T) {
 		_ = store.Init(ctx, suite.Head())
 	}()
 
-	h, err := store.GetByHeight(ctx, 1)
-	require.NoError(t, err)
-	require.NotNil(t, h)
+	_, err = store.GetByHeight(ctx, 1)
+	require.ErrorIs(t, err, header.ErrNotFound)
 }
 
 func TestStoreInit(t *testing.T) {

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -224,11 +224,16 @@ func TestSyncPendingRangesWithMisses(t *testing.T) {
 	exp, err := remoteStore.Head(ctx)
 	require.NoError(t, err)
 
-	have, err := localStore.Head(ctx)
-	require.NoError(t, err)
+	// we need to wait for a flush
+	assert.Eventually(t, func() bool {
+		have, err := localStore.Head(ctx)
+		require.NoError(t, err)
 
-	assert.Equal(t, exp.Height(), have.Height())
-	assert.Empty(t, syncer.pending.Head()) // assert all cache from pending is used
+		// assert.Equal(t, exp.Height(), have.Height())
+		// assert.Empty(t, syncer.pending.Head()) // assert all cache from pending is used
+
+		return exp.Height() == have.Height()
+	}, 2*time.Second, 100*time.Millisecond)
 }
 
 // TestSyncer_FindHeadersReturnsCorrectRange ensures that `findHeaders` returns

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -229,10 +229,14 @@ func TestSyncPendingRangesWithMisses(t *testing.T) {
 		have, err := localStore.Head(ctx)
 		require.NoError(t, err)
 
-		// assert.Equal(t, exp.Height(), have.Height())
-		// assert.Empty(t, syncer.pending.Head()) // assert all cache from pending is used
-
-		return exp.Height() == have.Height()
+		switch {
+		case exp.Height() != have.Height():
+			return false
+		case !syncer.pending.Head().IsZero():
+			return false
+		default:
+			return true
+		}
 	}, 2*time.Second, 100*time.Millisecond)
 }
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -47,19 +47,37 @@ func TestSyncSimpleRequestingHead(t *testing.T) {
 	err = syncer.SyncWait(ctx)
 	require.NoError(t, err)
 
-	exp, err := remoteStore.Head(ctx)
-	require.NoError(t, err)
+	// force sync to update underlying stores.
+	syncer.wantSync()
 
-	have, err := localStore.Head(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, exp.Height(), have.Height())
-	assert.Empty(t, syncer.pending.Head())
+	// we need to wait for a flush
+	assert.Eventually(t, func() bool {
+		exp, err := remoteStore.Head(ctx)
+		require.NoError(t, err)
 
-	state := syncer.State()
-	assert.Equal(t, uint64(exp.Height()), state.Height)
-	assert.Equal(t, uint64(2), state.FromHeight)
-	assert.Equal(t, uint64(exp.Height()), state.ToHeight)
-	assert.True(t, state.Finished(), state)
+		have, err := localStore.Head(ctx)
+		require.NoError(t, err)
+
+		state := syncer.State()
+		switch {
+		case exp.Height() != have.Height():
+			return false
+		case syncer.pending.Head() != nil:
+			return false
+
+		case uint64(exp.Height()) != state.Height:
+			return false
+		case uint64(2) != state.FromHeight:
+			return false
+
+		case uint64(exp.Height()) != state.ToHeight:
+			return false
+		case !state.Finished():
+			return false
+		default:
+			return true
+		}
+	}, 2*time.Second, 100*time.Millisecond)
 }
 
 func TestDoSyncFullRangeFromExternalPeer(t *testing.T) {


### PR DESCRIPTION
- Introduce a new unexported `Store` field which tracks the highest contiguous header observed.
- Rework `heightSub` to work only with height and not headers (drastically simplified internals and API)
- Load `headKey` on `Store.Start`
- `Store.Head` is much simpler, again
- `batch` will be reworked in the next PR.

Fixes #201