### PR TITLE
fix(syncer): don't Head recursively

### DIFF
--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -31,9 +31,8 @@ func (s *Syncer[H]) Head(ctx context.Context, _ ...header.HeadOption[H]) (H, err
 
 	// single-flight protection ensure only one Head is requested at the time
 	if !s.getter.Lock() {
-		// means that other routine held the lock and set the subjective head for us,
-		// so just recursively get it
-		return s.Head(ctx)
+		// means that other routine held the lock and set the subjective head
+		return s.subjectiveHead(ctx)
 	}
 	defer s.getter.Unlock()
 

--- a/sync/sync_head_test.go
+++ b/sync/sync_head_test.go
@@ -151,12 +151,10 @@ func (t *wrappedGetter) Head(ctx context.Context, options ...header.HeadOption[*
 }
 
 func (t *wrappedGetter) Get(ctx context.Context, hash header.Hash) (*headertest.DummyHeader, error) {
-	// TODO implement me
 	panic("implement me")
 }
 
 func (t *wrappedGetter) GetByHeight(ctx context.Context, u uint64) (*headertest.DummyHeader, error) {
-	// TODO implement me
 	panic("implement me")
 }
 
@@ -165,7 +163,6 @@ func (t *wrappedGetter) GetRangeByHeight(
 	from *headertest.DummyHeader,
 	to uint64,
 ) ([]*headertest.DummyHeader, error) {
-	// TODO implement me
 	panic("implement me")
 }
 
@@ -177,16 +174,13 @@ func (e errorGetter) Head(ctx context.Context, h ...header.HeadOption[*headertes
 }
 
 func (e errorGetter) Get(ctx context.Context, hash header.Hash) (*headertest.DummyHeader, error) {
-	//TODO implement me
 	panic("implement me")
 }
 
 func (e errorGetter) GetByHeight(ctx context.Context, u uint64) (*headertest.DummyHeader, error) {
-	//TODO implement me
 	panic("implement me")
 }
 
 func (e errorGetter) GetRangeByHeight(ctx context.Context, from *headertest.DummyHeader, to uint64) ([]*headertest.DummyHeader, error) {
-	//TODO implement me
 	panic("implement me")
 }


### PR DESCRIPTION
We don't need recursion here. If recent head request fails, all the waiters should simply return any known subjective head, like with other error cases.

Closes https://github.com/celestiaorg/go-header/issues/247