### PR TITLE
perf(p2p): avoid deserialization for locally published headers

### DIFF
--- a/p2p/subscriber.go
+++ b/p2p/subscriber.go
@@ -138,6 +138,8 @@ func (s *Subscriber[H]) Broadcast(ctx context.Context, header H, opts ...pubsub.
 	if err != nil {
 		return err
 	}
+
+	opts = append(opts, pubsub.WithValidatorData(header))
 	return s.topic.Publish(ctx, bin, opts...)
 }
 

--- a/p2p/subscriber.go
+++ b/p2p/subscriber.go
@@ -142,6 +142,12 @@ func (s *Subscriber[H]) Broadcast(ctx context.Context, header H, opts ...pubsub.
 }
 
 func (s *Subscriber[H]) verifyMessage(ctx context.Context, p peer.ID, msg *pubsub.Message) (res pubsub.ValidationResult) {
+	if msg.ValidatorData != nil {
+		// means the message is local and was already validated
+		// so simply accept it
+		return pubsub.ValidationAccept
+	}
+
 	defer func() {
 		err := recover()
 		if err != nil {


### PR DESCRIPTION
Blocked on https://github.com/libp2p/go-libp2p-pubsub/pull/603