### PR TITLE
fix(verify.go): Re-order the checks in order of sanity-check severity

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -53,6 +53,11 @@ func verify[H Header[H]](trstd, untrstd H) error {
 		return fmt.Errorf("%w: '%s' != '%s'", ErrWrongChainID, untrstd.ChainID(), trstd.ChainID())
 	}
 
+	known := untrstd.Height() <= trstd.Height()
+	if known {
+		return fmt.Errorf("%w: '%d' <= current '%d'", ErrKnownHeader, untrstd.Height(), trstd.Height())
+	}
+
 	if untrstd.Time().Before(trstd.Time()) {
 		return fmt.Errorf("%w: timestamp '%s' < current '%s'", ErrUnorderedTime, formatTime(untrstd.Time()), formatTime(trstd.Time()))
 	}
@@ -60,11 +65,6 @@ func verify[H Header[H]](trstd, untrstd H) error {
 	now := time.Now()
 	if untrstd.Time().After(now.Add(clockDrift)) {
 		return fmt.Errorf("%w: timestamp '%s' > now '%s', clock_drift '%v'", ErrFromFuture, formatTime(untrstd.Time()), formatTime(now), clockDrift)
-	}
-
-	known := untrstd.Height() <= trstd.Height()
-	if known {
-		return fmt.Errorf("%w: '%d' <= current '%d'", ErrKnownHeader, untrstd.Height(), trstd.Height())
 	}
 
 	return nil


### PR DESCRIPTION
In celestia-node, when a header comes through headersub that may be one header height behind (due to a slow broadcaster), where our subjective head is ahead of the incoming net head by 1, we actually catch that error due to its timestamp:

`
2025-03-19T14:37:16.320+0100	WARN	header/sync	sync/sync_head.go:181	invalid network header	{"height_of_invalid": 26314, "hash_of_invalid": "D5137A04DD552639D05D9369DE685C1F11B7D85FFCBDA0E54E66E55978C18000", "height_of_subjective": 26315, "hash_of_subjective": "6D968C6ED4C8B7B1B5EC1F883E11A02EFD3832DBDF2FD3AB9F9D8F3592227BA0", "reason": "unordered headers: timestamp '2025-03-19T13:36:53Z' < current '2025-03-19T13:37:02Z'"}
`

rather than just catching it via the height check. 

This PR reorders the check so that the error is more clear when this actually happens as it's not really due to unordered timestamps but rather an older header coming through.