### PR TITLE
refactor: extract VerifyRange and remove verification out of store

### DIFF
--- a/headertest/verify_test.go
+++ b/headertest/verify_test.go
@@ -181,7 +181,9 @@ func TestVerifyRange(t *testing.T) {
 			name: "non-adjacent header range ",
 			setup: func(suite *DummySuite) (*DummyHeader, []*DummyHeader) {
 				trusted := suite.GenDummyHeaders(1)[0]
-				_ = suite.GenDummyHeaders(1) // generate a header to ensure the range can be non-adjacent
+				_ = suite.GenDummyHeaders(
+					1,
+				) // generate a header to ensure the range can be non-adjacent
 				headers := suite.GenDummyHeaders(3)
 				headers = append(headers[0:1], headers[2:]...)
 				return trusted, headers
@@ -201,12 +203,16 @@ func TestVerifyRange(t *testing.T) {
 				var verErr *header.VerifyError
 				assert.ErrorAs(t, err, &verErr)
 				assert.ErrorIs(t, errors.Unwrap(verErr), tt.err)
-				assert.Len(t, verified, tt.verified, "unexpected number of verified headers before error")
+				assert.Len(t, verified, tt.verified)
 			} else {
 				assert.NoError(t, err)
-				assert.Len(t, verified, len(untrstd), "all headers should be verified")
+				assert.Len(t, verified, len(untrstd))
 				if len(untrstd) > 0 {
-					assert.Equal(t, untrstd[len(untrstd)-1], verified[len(verified)-1], "last verified header should match last input header")
+					assert.Equal(t,
+						untrstd[len(untrstd)-1],
+						verified[len(verified)-1],
+						"last verified header should match last input header",
+					)
 				}
 			}
 		})

--- a/headertest/verify_test.go
+++ b/headertest/verify_test.go
@@ -178,9 +178,10 @@ func TestVerifyRange(t *testing.T) {
 			verified: 2,
 		},
 		{
-			name: "non-adjacent headers",
+			name: "non-adjacent header range ",
 			setup: func(suite *DummySuite) (*DummyHeader, []*DummyHeader) {
 				trusted := suite.GenDummyHeaders(1)[0]
+				_ = suite.GenDummyHeaders(1) // generate a header to ensure the range can be non-adjacent
 				headers := suite.GenDummyHeaders(3)
 				headers = append(headers[0:1], headers[2:]...)
 				return trusted, headers

--- a/headertest/verify_test.go
+++ b/headertest/verify_test.go
@@ -125,3 +125,109 @@ func TestVerify(t *testing.T) {
 		})
 	}
 }
+
+func TestVerifyRange(t *testing.T) {
+	suite := NewTestSuite(t)
+	trusted := suite.GenDummyHeaders(1)[0]
+	var zero *DummyHeader
+
+	tests := []struct {
+		name     string
+		trusted  *DummyHeader
+		untrstd  []*DummyHeader
+		wantErr  bool
+		errType  error
+		verified int // number of headers that should be verified before error
+	}{
+		{
+			name:     "successful verification of all headers",
+			trusted:  trusted,
+			untrstd:  suite.GenDummyHeaders(5),
+			wantErr:  false,
+			verified: 5,
+		},
+		{
+			name:    "empty untrusted headers",
+			trusted: trusted,
+			untrstd: []*DummyHeader{},
+			wantErr: false,
+		},
+		{
+			name:    "verification fails in middle of range",
+			trusted: trusted,
+			untrstd: modifyHeaders(
+				suite.GenDummyHeaders(5),
+				2,
+				true,
+				false,
+			), // make 3rd header fail verification
+			wantErr:  true,
+			errType:  ErrDummyVerify,
+			verified: 2,
+		},
+		{
+			name:    "verification fails with soft failure",
+			trusted: trusted,
+			untrstd: modifyHeaders(
+				suite.GenDummyHeaders(5),
+				2,
+				true,
+				true,
+			), // make 3rd header fail with soft failure
+			wantErr:  true,
+			errType:  ErrDummyVerify,
+			verified: 2,
+		},
+		{
+			name:     "zero trusted header",
+			trusted:  zero,                 // use nil pointer
+			untrstd:  []*DummyHeader{zero}, // use nil pointer for untrusted header too
+			wantErr:  true,
+			errType:  header.ErrZeroHeader,
+			verified: 0, // no headers should be verified when trusted header is zero
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verified, err := header.VerifyRange(tt.trusted, tt.untrstd)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errType != nil {
+					var verErr *header.VerifyError
+					assert.ErrorAs(t, err, &verErr)
+					assert.ErrorIs(t, errors.Unwrap(verErr), tt.errType)
+				}
+				assert.Len(
+					t,
+					verified,
+					tt.verified,
+					"unexpected number of verified headers before error",
+				)
+			} else {
+				assert.NoError(t, err)
+				assert.Len(t, verified, len(tt.untrstd), "all headers should be verified")
+				if len(tt.untrstd) > 0 {
+					assert.Equal(t,
+						tt.untrstd[len(tt.untrstd)-1], verified[len(verified)-1],
+						"last verified header should match last input header",
+					)
+				}
+			}
+		})
+	}
+}
+
+// modifyHeaders is a helper function that modifies a header at the specified index to fail verification
+func modifyHeaders(
+	headers []*DummyHeader,
+	index int,
+	verifyFailure, softFailure bool,
+) []*DummyHeader {
+	if index < len(headers) {
+		headers[index].VerifyFailure = verifyFailure
+		headers[index].SoftFailure = softFailure
+	}
+	return headers
+}

--- a/local/exchange.go
+++ b/local/exchange.go
@@ -34,9 +34,13 @@ func (l *Exchange[H]) GetByHeight(ctx context.Context, height uint64) (H, error)
 	return l.store.GetByHeight(ctx, height)
 }
 
-func (l *Exchange[H]) GetRangeByHeight(ctx context.Context, from H, to uint64,
-) ([]H, error) {
-	return l.store.GetRangeByHeight(ctx, from, to)
+func (l *Exchange[H]) GetRangeByHeight(ctx context.Context, from H, to uint64) ([]H, error) {
+	headers, err := l.store.GetRangeByHeight(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	return header.VerifyRange(from, headers)
 }
 
 func (l *Exchange[H]) Get(ctx context.Context, hash header.Hash) (H, error) {

--- a/p2p/session_test.go
+++ b/p2p/session_test.go
@@ -1,15 +1,8 @@
 package p2p
 
 import (
-	"context"
-	"testing"
-	"time"
-
-	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/celestiaorg/go-header/headertest"
+	"testing"
 )
 
 func Test_PrepareRequests(t *testing.T) {
@@ -19,40 +12,4 @@ func Test_PrepareRequests(t *testing.T) {
 	require.Len(t, requests, 2)
 	require.Equal(t, requests[0].GetOrigin(), uint64(1))
 	require.Equal(t, requests[1].GetOrigin(), uint64(6))
-}
-
-// Test_Validate ensures that headers range is adjacent and valid.
-func Test_Validate(t *testing.T) {
-	suite := headertest.NewTestSuite(t)
-	head := suite.Head()
-	ses := newSession(
-		context.Background(),
-		nil,
-		&peerTracker{trackedPeers: make(map[peer.ID]*peerStat)},
-		"", time.Second, nil,
-		withValidation(head),
-	)
-
-	headers := suite.GenDummyHeaders(5)
-	err := ses.verify(headers)
-	assert.NoError(t, err)
-}
-
-// Test_ValidateFails ensures that non-adjacent range will return an error.
-func Test_ValidateFails(t *testing.T) {
-	suite := headertest.NewTestSuite(t)
-	head := suite.Head()
-	ses := newSession(
-		context.Background(),
-		nil,
-		&peerTracker{trackedPeers: make(map[peer.ID]*peerStat)},
-		"", time.Second, nil,
-		withValidation(head),
-	)
-
-	headers := suite.GenDummyHeaders(5)
-	// break adjacency
-	headers[2] = headers[4]
-	err := ses.verify(headers)
-	assert.Error(t, err)
 }

--- a/p2p/session_test.go
+++ b/p2p/session_test.go
@@ -1,8 +1,9 @@
 package p2p
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_PrepareRequests(t *testing.T) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -126,25 +126,6 @@ func TestStore_GetRangeByHeight_ExpectedRange(t *testing.T) {
 	assert.Equal(t, lastHeaderInRangeHeight, out[len(out)-1].Height())
 }
 
-func TestStore_Append_BadHeader(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	t.Cleanup(cancel)
-
-	suite := headertest.NewTestSuite(t)
-
-	ds := sync.MutexWrap(datastore.NewMapDatastore())
-	store := NewTestStore(t, ctx, ds, suite.Head())
-
-	head, err := store.Head(ctx)
-	require.NoError(t, err)
-	assert.EqualValues(t, suite.Head().Hash(), head.Hash())
-
-	in := suite.GenDummyHeaders(10)
-	in[0].VerifyFailure = true
-	err = store.Append(ctx, in...)
-	require.Error(t, err)
-}
-
 // TestStore_GetRange tests possible combinations of requests and ensures that
 // the store can handle them adequately (even malformed requests)
 func TestStore_GetRange(t *testing.T) {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -291,19 +291,8 @@ func (s *Syncer[H]) processHeaders(
 			}
 		}
 
-		// verify pending heads as they might be invalid
-		// particularly headers that failed verification with soft failure
-		// but were accepted as sync target
-		// TODO(@Wondertan): This repeats verification for valid heads.
-		//   But this is acceptable trade-off for simplicity which is gonna be
-		//   refactored off with backward sync over MMR anyway.
-		verified, err := s.verifyHeaders(ctx, headers)
-		if err != nil {
-			return err
-		}
-
 		// apply cached headers
-		if err := s.store.Append(ctx, verified...); err != nil {
+		if err := s.store.Append(ctx, headers...); err != nil {
 			return err
 		}
 
@@ -346,19 +335,4 @@ func (s *Syncer[H]) requestHeaders(
 		fromHead = headers[len(headers)-1]
 	}
 	return nil
-}
-
-// verifyHeaders verifies given headers against the store's head.
-func (s *Syncer[H]) verifyHeaders(ctx context.Context, headers []H) ([]H, error) {
-	head, err := s.store.Head(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	verified, err := header.VerifyRange(head, headers)
-	if err != nil {
-		return nil, err
-	}
-
-	return verified, nil
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -291,8 +291,19 @@ func (s *Syncer[H]) processHeaders(
 			}
 		}
 
+		// verify pending heads as they might be invalid
+		// particularly headers that failed verification with soft failure
+		// but were accepted as sync target
+		// TODO(@Wondertan): This repeats verification for valid heads.
+		//   But this is acceptable trade-off for simplicity which is gonna be
+		//   refactored off with backward sync over MMR anyway.
+		verified, err := s.verifyHeaders(ctx, headers)
+		if err != nil {
+			return err
+		}
+
 		// apply cached headers
-		if err := s.store.Append(ctx, headers...); err != nil {
+		if err := s.store.Append(ctx, verified...); err != nil {
 			return err
 		}
 
@@ -335,4 +346,19 @@ func (s *Syncer[H]) requestHeaders(
 		fromHead = headers[len(headers)-1]
 	}
 	return nil
+}
+
+// verifyHeaders verifies given headers against the store's head.
+func (s *Syncer[H]) verifyHeaders(ctx context.Context, headers []H) ([]H, error) {
+	head, err := s.store.Head(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	verified, err := header.VerifyRange(head, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	return verified, nil
 }

--- a/verify.go
+++ b/verify.go
@@ -13,7 +13,7 @@ import (
 func VerifyRange[H Header[H]](trstd H, untrstd []H) ([]H, error) {
 	verified := make([]H, 0, len(untrstd))
 	for _, h := range untrstd {
-		err := trstd.Verify(h)
+		err := Verify(trstd, h)
 		if err != nil {
 			return verified, err
 		}

--- a/verify.go
+++ b/verify.go
@@ -16,14 +16,16 @@ func VerifyRange[H Header[H]](trstd H, untrstdRange []H) ([]H, error) {
 	}
 
 	verified := make([]H, 0, len(untrstdRange))
-	for _, untrstd := range untrstdRange {
+	for i, untrstd := range untrstdRange {
 		err := Verify(trstd, untrstd)
 		if err != nil {
 			return verified, err
 		}
 
 		// ensure range is adjacent, as Verify allows non-adjacency
-		if trstd.Height()+1 != untrstd.Height() {
+		// NOTE: i > 0 because we allow the input trusted header to be non-adjacent
+		// so given trusted header height 100, we can have untrusted 151-155
+		if i > 0 && trstd.Height()+1 != untrstd.Height() {
 			reason := fmt.Errorf(
 				"%w; trusted: %d, expected_untrusted: %d, received_untrusted: %d",
 				ErrNonAdjacentRange,

--- a/verify.go
+++ b/verify.go
@@ -6,6 +6,24 @@ import (
 	"time"
 )
 
+// VerifyRange verifies untrusted Headers against trusted following general Header checks and
+// custom user-specific checks defined in [Verify].
+//
+// In case of error, returns verified sub-range of Headers and error.
+func VerifyRange[H Header[H]](trstd H, untrstd []H) ([]H, error) {
+	verified := make([]H, 0, len(untrstd))
+	for _, h := range untrstd {
+		err := trstd.Verify(h)
+		if err != nil {
+			return verified, err
+		}
+		verified = append(verified, h)
+		trstd = h
+	}
+
+	return verified, nil
+}
+
 // Verify verifies untrusted Header against trusted following general Header checks and
 // custom user-specific checks defined in Header.Verify.
 //


### PR DESCRIPTION
Removes verification out of the Store => requires local exchange to do verification => extracts canonical VerifyRange with unit testing => uncovers minor edge cases with range verification

Closes #266 