### PR TITLE
fix(store): support complete erase

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -319,7 +319,7 @@ func (s *Store[H]) DeleteTo(ctx context.Context, to uint64) error {
 			)
 		}
 
-		//  if `to` is bigger than current head and is stored - allow delete making `to` a new head
+		//  if `to` is bigger than the current head and is stored - allow delete, making `to` a new head
 	}
 
 	tail, err := s.Tail(ctx)
@@ -398,7 +398,7 @@ func (s *Store[H]) updateTail(ctx context.Context, batch datastore.Batch, to uin
 		}
 
 		if to <= head.Height() {
-			return err
+			return fmt.Errorf("attempt to delete to %d: %w", to, header.ErrNotFound)
 		}
 
 		// TODO(@Wondertan): this is racy, but not critical

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -536,8 +536,7 @@ func TestStore_DeleteTo(t *testing.T) {
 		{
 			name:      "no-op delete request",
 			to:        5,
-			wantTail:  14,
-			wantError: false,
+			wantError: true,
 		},
 		{
 			name:      "valid delete request",
@@ -547,8 +546,7 @@ func TestStore_DeleteTo(t *testing.T) {
 		},
 		{
 			name:      "higher than head",
-			to:        1055,
-			wantTail:  30,
+			to:        103,
 			wantError: true,
 		},
 	}
@@ -582,9 +580,51 @@ func TestStore_DeleteTo(t *testing.T) {
 
 			tail, err := store.Tail(ctx)
 			require.NoError(t, err)
-			require.EqualValues(t, tail.Height(), tt.wantTail)
+			require.EqualValues(t, tt.wantTail, tail.Height())
 		})
 	}
+}
+
+func TestStore_DeleteTo_EmptyStore(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	store, err := NewStore[*headertest.DummyHeader](ds)
+	require.NoError(t, err)
+
+	err = store.Start(ctx)
+	require.NoError(t, err)
+
+	err = store.Append(ctx, suite.GenDummyHeaders(100)...)
+	require.NoError(t, err)
+	time.Sleep(10 * time.Millisecond)
+
+	err = store.DeleteTo(ctx, 101)
+	require.NoError(t, err)
+
+	// assert store is empty
+	tail, err := store.Tail(ctx)
+	assert.Nil(t, tail)
+	assert.ErrorIs(t, err, header.ErrEmptyStore)
+	head, err := store.Head(ctx)
+	assert.Nil(t, head)
+	assert.ErrorIs(t, err, header.ErrEmptyStore)
+
+	// assert that it is still empty even after restart
+	err = store.Stop(ctx)
+	require.NoError(t, err)
+	err = store.Start(ctx)
+	require.NoError(t, err)
+
+	tail, err = store.Tail(ctx)
+	assert.Nil(t, tail)
+	assert.ErrorIs(t, err, header.ErrEmptyStore)
+	head, err = store.Head(ctx)
+	assert.Nil(t, head)
+	assert.ErrorIs(t, err, header.ErrEmptyStore)
 }
 
 func TestStorePendingCacheMiss(t *testing.T) {


### PR DESCRIPTION
Previously Store allowed deleting up to the Head. This change allows deleting including the head too, ensuring proper cleanup of Store's state in such a case. If head is `5` and `DeleteTo(6)` is called, the store will handle this case now.

Additionally, if head was `5` and `DeleteTo(7)` is called, while `7`and `8` exists in the store, they will become Tail and Head respectively. 

Closes #284 