### PR TITLE
chore(sync): improve bifurcation logs

### DIFF
--- a/sync/sync_head.go
+++ b/sync/sync_head.go
@@ -190,6 +190,7 @@ func (s *Syncer[H]) verify(ctx context.Context, newHead H) error {
 // A non-nil error is returned when newHead can't be verified or is invalid.
 func (s *Syncer[H]) verifyBifurcating(ctx context.Context, subjHead, newHead H) error {
 	log.Infow("bifurcation: verifying new head", "height", newHead.Height())
+	s.metrics.bifurcation(ctx, newHead.Height(), newHead.Hash().String())
 
 	subjHeight := subjHead.Height()
 	diff := newHead.Height() - subjHeight


### PR DESCRIPTION
So I was debugging something related to bifurcation. I turned on logs and realized they are not helpful at all - confusing and lacks info.

This PR fixes make logs more readable, yet, it brings a few other improvements:
* Better error when newHead is confirmed to be invalid. It should return the actual error from `Verify` rather then making a new one that has no context on what actually failed there.
* Aligns terminology with broader Syncer
* Adds a new metric to count  bifurcation events