### PR TITLE
fix(syncer): check tail hash via len

### DIFF
--- a/sync/syncer_tail.go
+++ b/sync/syncer_tail.go
@@ -141,7 +141,7 @@ func (s *Syncer[H]) moveTail(ctx context.Context, from, to H) error {
 // Returns empty hash if it hasn't changed from the old tail hash.
 func (s *Syncer[H]) tailHash(oldTail H) (bool, header.Hash) {
 	hash := s.Params.SyncFromHash
-	if hash == nil {
+	if len(hash) == 0 {
 		return false, nil
 	}
 


### PR DESCRIPTION
A non-nil but empty hash could be passed, so check the len