### PR TITLE
refactor(sync): `SyncFromHash` as string

### DIFF
--- a/sync/syncer_tail.go
+++ b/sync/syncer_tail.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -140,8 +141,12 @@ func (s *Syncer[H]) moveTail(ctx context.Context, from, to H) error {
 // tailHash reports whether tail hash should be used and returns it.
 // Returns empty hash if it hasn't changed from the old tail hash.
 func (s *Syncer[H]) tailHash(oldTail H) (bool, header.Hash) {
-	hash := s.Params.SyncFromHash
-	if len(hash) == 0 {
+	hashStr := s.Params.SyncFromHash
+	if len(hashStr) == 0 {
+		return false, nil
+	}
+	hash, err := hex.DecodeString(hashStr)
+	if err != nil {
 		return false, nil
 	}
 

--- a/sync/syncer_tail_test.go
+++ b/sync/syncer_tail_test.go
@@ -37,7 +37,7 @@ func TestSyncer_TailHashOverHeight(t *testing.T) {
 		localStore,
 		headertest.NewDummySubscriber(),
 		WithBlockTime(headertest.HeaderTime),
-		WithSyncFromHash(startFrom.Hash()),
+		WithSyncFromHash(startFrom.Hash().String()),
 	)
 	require.NoError(t, err)
 
@@ -195,7 +195,7 @@ func TestSyncer_TailInitialization(t *testing.T) {
 		},
 		{
 			"SyncFromHash",
-			WithSyncFromHash(expectedTail.Hash()),
+			WithSyncFromHash(expectedTail.Hash().String()),
 			func() *headertest.DummyHeader {
 				return expectedTail
 			},
@@ -258,7 +258,7 @@ func TestSyncer_TailInitialization(t *testing.T) {
 			require.NoError(t, err)
 			expectedTail = test.expectedAfterRestart()
 			syncer.Params.SyncFromHeight = expectedTail.Height()
-			syncer.Params.SyncFromHash = expectedTail.Hash()
+			syncer.Params.SyncFromHash = expectedTail.Hash().String()
 
 			// simulate new head
 			err = remoteStore.Append(ctx, suite.NextHeader())


### PR DESCRIPTION
Otherwise, it's ignored by the config toml