### PR TITLE
fix(sync): prevent concurrent tail movements

### DIFF
--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -47,6 +47,8 @@ type Syncer[H header.Header[H]] struct {
 	pending ranges[H]
 	// incomingMu ensures only one incoming network head candidate is processed at the time
 	incomingMu sync.Mutex
+	// tailMu prevents concurrent tail movements
+	tailMu sync.Mutex
 
 	// controls lifecycle for syncLoop
 	ctx    context.Context


### PR DESCRIPTION
Moving tail(or pruning) may take a lot of time, while it happens, new network heads can arrive, interfering with the in-progress move. This change simply detects that and skips tail processing if there is one in progress