### PR TITLE
fix(sync): hack preventing duplicate work

### DIFF
--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -53,6 +53,11 @@ type Syncer[H header.Header[H]] struct {
 	cancel context.CancelFunc
 
 	Params *Parameters
+
+	// a hack to temporary keep sbjHead around during subjective init
+	// TODO(@Wondertan): Remove after bsync.
+	sbjHeadMu sync.Mutex
+	sbjHead   H
 }
 
 // NewSyncer creates a new instance of Syncer.


### PR DESCRIPTION
A duplicate request strikes again, and this time in an even more meticulous manner. The solution is a quick hack that keeps some state around that should not be there. The better solution I have in mind depends on backwards sync, so this one should be sufficient until then. For more details, see the long HACK comment.

Tested manually.  