### PR TITLE
fix(sync): stall headersub until Syncer has started

### DIFF
--- a/sync/syncer_head.go
+++ b/sync/syncer_head.go
@@ -192,15 +192,6 @@ func (s *Syncer[H]) setLocalHead(ctx context.Context, netHead H) {
 // incomingNetworkHead processes new potential network heads.
 // If the header is valid, sets as the new subjective header.
 func (s *Syncer[H]) incomingNetworkHead(ctx context.Context, head H) error {
-	// HACK(@Wondertan):
-	if s.sbjInitWait {
-		select {
-		case <-s.sbjInitSema:
-		default:
-			close(s.sbjInitSema)
-		}
-	}
-
 	// ensure there is no racing between network head candidates
 	// additionally ensures there is only one bifurcation attempt at a time
 	s.incomingMu.Lock()


### PR DESCRIPTION
A better version of #316. This version should be easier to understand, but it also addresses a corruption case that I realized #316 doesn't cover.  If, for whatever reason, Tail request during the very first start takes more time, then the duplicate subjective init, triggered by the network head from headersub,  then the network head will be stored before tail, breaking the further syncing attempts irrecoverably.

This will be removed with bsync once the requirement to store Tail before Head is removed.

EDIT: [f569260](https://github.com/celestiaorg/go-header/pull/317/commits/f56926051d9755a6189c49d2efbcc48446560ce0) completely stalls headersub until started on every start, not just subj init. During a regular start, a headersub header may frontrun the Start routine and trigger Tail update first. This is problematic as the node assumes the Tail is up-to-date after Start finishes, but in the front-running case, only the headersub routine gets blocked (see #313).

Extensively tested manually.