### PR TITLE
fix: added cause of timeout for non test files

### DIFF
--- a/p2p/peer_tracker.go
+++ b/p2p/peer_tracker.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -268,7 +269,7 @@ func (p *peerTracker) dumpPeers(ctx context.Context) {
 	}
 	p.peerLk.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	ctx, cancel := context.WithTimeoutCause(ctx, time.Second*5, errors.New("dumping peers timeout "))
 	defer cancel()
 
 	err := p.pidstore.Put(ctx, peers)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -106,7 +106,7 @@ func (serv *ExchangeServer[H]) requestHandler(stream network.Stream) {
 		log.Error(err)
 	}
 
-	ctx, cancel := context.WithTimeout(serv.ctx, serv.Params.RequestTimeout)
+	ctx, cancel := context.WithTimeoutCause(serv.ctx, serv.Params.RequestTimeout, errors.New("server "+string(serv.host.ID())+": request timed out "))
 	defer cancel()
 
 	var headers []H

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -85,7 +86,7 @@ func TestExchangeServer_Timeout(t *testing.T) {
 		{
 			name: "handleHeadRequest",
 			fn: func() error {
-				ctx, cancel := context.WithTimeout(context.Background(), testRequestTimeout)
+				ctx, cancel := context.WithTimeoutCause(context.Background(), testRequestTimeout, errors.New(" test: server request timeout"))
 				defer cancel()
 
 				_, err := server.handleHeadRequest(ctx)

--- a/p2p/session.go
+++ b/p2p/session.go
@@ -182,7 +182,7 @@ func (s *session[H]) doRequest(
 	))
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(ctx, s.requestTimeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, s.requestTimeout, errors.New("peer "+string(stat.peerID)+": request timed out"))
 	defer cancel()
 
 	start := time.Now()

--- a/sync/syncer_head.go
+++ b/sync/syncer_head.go
@@ -63,7 +63,7 @@ func (s *Syncer[H]) networkHead(ctx context.Context) (H, bool, error) {
 	log.Warnw("attempting to request the most recent network head...")
 
 	// cap the max blocking time for the request call
-	ctx, cancel := context.WithTimeout(ctx, NetworkHeadRequestTimeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, NetworkHeadRequestTimeout, errors.New("network head request time out "))
 	defer cancel()
 
 	newHead, err := s.head.Head(ctx, header.WithTrustedHead[H](sbjHead))


### PR DESCRIPTION

- **Issue** : #312  
- **Title** : [Migrate to context.WithTimeoutCause](https://github.com/celestiaorg/go-header/issues/312)
- **Proposed fix** : In order to track which context timed out , i changed the context.WithTimeOut with context.WithTimeOutCause , where cause is an error . for now i changed all non test files .
- **Objective** : improve devx/ux  
