### PR TITLE
fix(sync): subj init death loop

### DIFF
--- a/sync/syncer_head.go
+++ b/sync/syncer_head.go
@@ -227,7 +227,11 @@ func (s *Syncer[H]) incomingNetworkHead(ctx context.Context, head H) error {
 
 // verify verifies given network head candidate.
 func (s *Syncer[H]) verify(ctx context.Context, newHead H) error {
-	sbjHead, _, err := s.subjectiveHead(ctx)
+	// TODO(@Wondertan): This has to be subjective head.
+	//  But due to an edge case during subjective init, this might be an expired tail
+	//  triggering subjective reinit death loop.
+	//  This can and will be fixed with bsync,
+	sbjHead, err := s.localHead(ctx)
 	if err != nil {
 		log.Errorw("getting subjective head during new network head verification", "err", err)
 		return err


### PR DESCRIPTION
During subjective init, we verify the head against the tail. However, the tail may be configured to be outside of the trusting window, causing subjective init "deathloop". 

Once the tail is requested, it is immediately stored as the first-ever header. However, this tail is also a head for a brief moment before the network head gets applied in `incomingNewHead`. And when `verify` inside of it calls `subjectiveHead`, the temporary head tail is considered expired, causing re-requesting of the new head. However, this new head fails verification as it's the same as the network head awaiting to be applied. Then this whole process goes nuts in cycles.

This is actually also a solution for the original problem described in #317, but it does not solve the secondary problem in the EDIT section, so we still need to keep #317 