### PR TITLE
refactor(sync): privatise trustingPeriod in syncer params

### DIFF
--- a/sync/options.go
+++ b/sync/options.go
@@ -14,15 +14,6 @@ type Option func(*Parameters)
 
 // Parameters is the set of parameters that must be configured for the syncer.
 type Parameters struct {
-	// TrustingPeriod is period through which we can trust a header's validators set.
-	//
-	// Should be significantly less than the unbonding period (e.g. unbonding
-	// period = 3 weeks, trusting period = 2 weeks).
-	//
-	// More specifically, trusting period + time needed to check headers + time
-	// needed to report and punish misbehavior should be less than the unbonding
-	// period.
-	TrustingPeriod time.Duration
 	// PruningWindow defines the duration within which headers are retained before being pruned.
 	PruningWindow time.Duration
 	// SyncFromHash is the hash of the header from which Syncer should start syncing.
@@ -41,6 +32,15 @@ type Parameters struct {
 	//
 	// SyncFromHeight has lower priority than SyncFromHash.
 	SyncFromHeight uint64
+	// trustingPeriod is period through which we can trust a header's validators set.
+	//
+	// Should be significantly less than the unbonding period (e.g. unbonding
+	// period = 3 weeks, trusting period = 2 weeks).
+	//
+	// More specifically, trusting period + time needed to check headers + time
+	// needed to report and punish misbehavior should be less than the unbonding
+	// period.
+	trustingPeriod time.Duration
 	// blockTime provides a reference point for the Syncer to determine
 	// whether its subjective head is outdated.
 	// Keeping it private to disable serialization for it.
@@ -58,14 +58,14 @@ type Parameters struct {
 // DefaultParameters returns the default params to configure the syncer.
 func DefaultParameters() Parameters {
 	return Parameters{
-		TrustingPeriod: 336 * time.Hour, // tendermint's default trusting period
+		trustingPeriod: 336 * time.Hour, // tendermint's default trusting period
 		PruningWindow:  337 * time.Hour,
 	}
 }
 
 func (p *Parameters) Validate() error {
-	if p.TrustingPeriod == 0 {
-		return fmt.Errorf("invalid TrustingPeriod duration: %v", p.TrustingPeriod)
+	if p.trustingPeriod == 0 {
+		return fmt.Errorf("invalid trustingPeriod duration: %v", p.trustingPeriod)
 	}
 	if p.SyncFromHash == "" && p.PruningWindow == 0 && p.SyncFromHeight == 0 {
 		return fmt.Errorf(
@@ -115,10 +115,10 @@ func WithRecencyThreshold(threshold time.Duration) Option {
 }
 
 // WithTrustingPeriod is a functional option that configures the
-// `TrustingPeriod` parameter.
+// `trustingPeriod` parameter.
 func WithTrustingPeriod(duration time.Duration) Option {
 	return func(p *Parameters) {
-		p.TrustingPeriod = duration
+		p.trustingPeriod = duration
 	}
 }
 

--- a/sync/syncer_head.go
+++ b/sync/syncer_head.go
@@ -129,7 +129,7 @@ func (s *Syncer[H]) networkHead(ctx context.Context) (H, bool, error) {
 func (s *Syncer[H]) subjectiveHead(ctx context.Context) (H, bool, error) {
 	sbjHead, err := s.localHead(ctx)
 
-	switch expired, expiredFor := isExpired(sbjHead, s.Params.TrustingPeriod); {
+	switch expired, expiredFor := isExpired(sbjHead, s.Params.trustingPeriod); {
 	case expired:
 		log.Infow(
 			"subjective head expired, reinitializing...",
@@ -152,7 +152,7 @@ func (s *Syncer[H]) subjectiveHead(ctx context.Context) (H, bool, error) {
 		return newHead, false, fmt.Errorf("exchange head: %w", err)
 	}
 	// still check if even the newly requested head is expired
-	if expired, expiredFor := isExpired(newHead, s.Params.TrustingPeriod); expired {
+	if expired, expiredFor := isExpired(newHead, s.Params.trustingPeriod); expired {
 		// forbid initializing off an expired header
 		err := fmt.Errorf(
 			"subjective initialization with header(%d) expired for %s",

--- a/sync/syncer_tail.go
+++ b/sync/syncer_tail.go
@@ -200,7 +200,7 @@ func (s *Syncer[H]) tailHeight(ctx context.Context, oldTail, head H) (uint64, er
 // estimateTailHeight estimates the tail header based on the current head.
 // It respects the trusting period, ensuring Syncer never initializes off an expired header.
 func (s *Syncer[H]) estimateTailHeight(head H) uint64 {
-	headersToRetain := uint64(s.Params.TrustingPeriod / s.Params.blockTime) //nolint:gosec
+	headersToRetain := uint64(s.Params.trustingPeriod / s.Params.blockTime) //nolint:gosec
 	if headersToRetain >= head.Height() {
 		// means chain is very young so we can keep all headers starting from genesis
 		return 1


### PR DESCRIPTION
Do not expose `trustingPeriod` to node operator - privatise in syncer params.