### PR TITLE
fix(store): fixes rare race condition where 2 workers attempt to close errCh at same time

### DIFF
--- a/store/store_delete.go
+++ b/store/store_delete.go
@@ -256,6 +256,8 @@ func (s *Store[H]) deleteParallel(ctx context.Context, from, to uint64) (uint64,
 	}
 	results := make([]result, workerNum)
 	jobCh := make(chan uint64, workerNum)
+
+	var closeErrChOnce sync.Once
 	errCh := make(chan error)
 
 	worker := func(worker int) {
@@ -263,11 +265,9 @@ func (s *Store[H]) deleteParallel(ctx context.Context, from, to uint64) (uint64,
 		defer func() {
 			results[worker] = last
 			if last.err != nil {
-				select {
-				case <-errCh:
-				default:
+				closeErrChOnce.Do(func() {
 					close(errCh)
-				}
+				})
 			}
 		}()
 


### PR DESCRIPTION
```
2025-11-13T10:57:16.731-0500	INFO	pruner/service	pruner/checkpoint.go:78	loaded checkpoint	{"last_pruned_height": 7764854, "failed_headers": 0}
panic: close of closed channel

goroutine 1327 [running]:
github.com/celestiaorg/go-header/store.(*Store[...]).deleteParallel.func1.1()
	/Users/rene/go/pkg/mod/github.com/celestiaorg/go-header@v0.7.3/store/store_delete.go:269 +0x84
github.com/celestiaorg/go-header/store.(*Store[...]).deleteParallel.func1()
	/Users/rene/go/pkg/mod/github.com/celestiaorg/go-header@v0.7.3/store/store_delete.go:293 +0x228
github.com/celestiaorg/go-header/store.(*Store[...]).deleteParallel.func2()
	/Users/rene/go/pkg/mod/github.com/celestiaorg/go-header@v0.7.3/store/store_delete.go:300 +0x4c
created by github.com/celestiaorg/go-header/store.(*Store[...]).deleteParallel in goroutine 286
	/Users/rene/go/pkg/mod/github.com/celestiaorg/go-header@v0.7.3/store/store_delete.go:298 +0x3cc
```