### PR TITLE
fix(sync): write to tail metric in newTail

### DIFF
--- a/store/metrics.go
+++ b/store/metrics.go
@@ -81,7 +81,7 @@ func (m *metrics) newHead(height uint64) {
 
 func (m *metrics) newTail(height uint64) {
 	m.observe(context.Background(), func(context.Context) {
-		m.headHeight.Store(height)
+		m.tailHeight.Store(height)
 	})
 }
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
the chain head metric `celestia_lightnode_hdr_store_head_height_gauge` is being written to for both tails and heads, causing the metric to report two heights
<img width="1494" height="655" alt="image" src="https://github.com/user-attachments/assets/dffa7fff-971e-4384-b707-cf1f07ad53f3" />
while the tail metric `celestia_lightnode_hdr_store_tail_height_gauge` stays flat at 0:
<img width="1503" height="483" alt="image" src="https://github.com/user-attachments/assets/e6b823c0-b2d2-4062-b948-b6ef6d23162e" />

this is caused by the error in `newTail` method, this PR aims to fix that
