### PR TITLE
feat: use go-libp2p-pubsub fork with FanoutOnly support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,3 +108,5 @@ require (
 )
 
 replace github.com/libp2p/go-libp2p => github.com/celestiaorg/go-libp2p v0.0.0-20260227132409-ca1f74a6feb6
+
+replace github.com/libp2p/go-libp2p-pubsub => github.com/celestiaorg/go-libp2p-pubsub v0.6.2-0.20260225133553-213565e2a428

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/celestiaorg/go-libp2p v0.0.0-20260227132409-ca1f74a6feb6 h1:GS5xo6ieb
 github.com/celestiaorg/go-libp2p v0.0.0-20260227132409-ca1f74a6feb6/go.mod h1:TbIDnpDjBLa7isdgYpbxozIVPBTmM/7qKOJP4SFySrQ=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
+github.com/celestiaorg/go-libp2p-pubsub v0.6.2-0.20260225133553-213565e2a428 h1:xoPAwLmTwmwUCDZ8shNCTyMMXEjU/5O0bSyuTBBRkeA=
+github.com/celestiaorg/go-libp2p-pubsub v0.6.2-0.20260225133553-213565e2a428/go.mod h1:lr4oE8bFgQaifRcoc2uWhWWiK6tPdOEKpUuR408GFN4=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -67,8 +69,6 @@ github.com/libp2p/go-flow-metrics v0.2.0 h1:EIZzjmeOE6c8Dav0sNv35vhZxATIXWZg6j/C
 github.com/libp2p/go-flow-metrics v0.2.0/go.mod h1:st3qqfu8+pMfh+9Mzqb2GTiwrAGjIPszEjZmtksN8Jc=
 github.com/libp2p/go-libp2p-asn-util v0.4.1 h1:xqL7++IKD9TBFMgnLPZR6/6iYhawHKHl950SO9L6n94=
 github.com/libp2p/go-libp2p-asn-util v0.4.1/go.mod h1:d/NI6XZ9qxw67b4e+NgpQexCIiFYJjErASrYW4PFDN8=
-github.com/libp2p/go-libp2p-pubsub v0.15.0 h1:cG7Cng2BT82WttmPFMi50gDNV+58K626m/wR00vGL1o=
-github.com/libp2p/go-libp2p-pubsub v0.15.0/go.mod h1:lr4oE8bFgQaifRcoc2uWhWWiK6tPdOEKpUuR408GFN4=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
 github.com/libp2p/go-msgio v0.3.0 h1:mf3Z8B1xcFN314sWX+2vOTShIE0Mmn2TXn3YCUQGNj0=

--- a/p2p/subscriber.go
+++ b/p2p/subscriber.go
@@ -20,6 +20,7 @@ type SubscriberOption func(*SubscriberParams)
 type SubscriberParams struct {
 	networkID string
 	metrics   bool
+	topicOpts []pubsub.TopicOpt
 }
 
 // Subscriber manages the lifecycle and relationship of header Module
@@ -27,10 +28,11 @@ type SubscriberParams struct {
 type Subscriber[H header.Header[H]] struct {
 	pubsubTopicID string
 
-	metrics *subscriberMetrics
-	pubsub  *pubsub.PubSub
-	topic   *pubsub.Topic
-	msgID   pubsub.MsgIdFunction
+	metrics   *subscriberMetrics
+	pubsub    *pubsub.PubSub
+	topic     *pubsub.Topic
+	msgID     pubsub.MsgIdFunction
+	topicOpts []pubsub.TopicOpt
 
 	verifierMu   sync.Mutex
 	verifierSema chan struct{} // closed when verifier is set
@@ -48,6 +50,14 @@ func WithSubscriberMetrics() SubscriberOption {
 func WithSubscriberNetworkID(networkID string) SubscriberOption {
 	return func(params *SubscriberParams) {
 		params.networkID = networkID
+	}
+}
+
+// WithTopicOpts sets additional pubsub.TopicOpt options for the topic.
+// This can be used to configure topic-level behavior such as pubsub.FanoutOnly().
+func WithTopicOpts(opts ...pubsub.TopicOpt) SubscriberOption {
+	return func(params *SubscriberParams) {
+		params.topicOpts = append(params.topicOpts, opts...)
 	}
 }
 
@@ -77,6 +87,7 @@ func NewSubscriber[H header.Header[H]](
 		pubsubTopicID: PubsubTopicID(params.networkID),
 		pubsub:        ps,
 		msgID:         msgID,
+		topicOpts:     params.topicOpts,
 		verifierSema:  make(chan struct{}),
 	}, nil
 }
@@ -90,7 +101,8 @@ func (s *Subscriber[H]) Start(context.Context) (err error) {
 		return err
 	}
 
-	topic, err := s.pubsub.Join(s.pubsubTopicID, pubsub.WithTopicMessageIdFn(s.msgID))
+	topicOpts := append([]pubsub.TopicOpt{pubsub.WithTopicMessageIdFn(s.msgID)}, s.topicOpts...)
+	topic, err := s.pubsub.Join(s.pubsubTopicID, topicOpts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
 ## Summary                                                                                                                                       
  - Replace `go-libp2p-pubsub` with celestiaorg fork (celestiaorg/go-libp2p-pubsub@213565e2) that introduces `FanoutOnly` topic option
  - Add `WithTopicOpts` subscriber option to pass topic-level options through to `pubsub.Join`

  ## Usage
  ```go
  sub, err := p2p.NewSubscriber[H](ps, msgIDFn,
      p2p.WithTopicOpts(pubsub.FanoutOnly()),
  )

  FanoutOnly allows nodes to publish to a topic without joining the gossipsub mesh.