### PR TITLE
fix: use go-libp2p fork with mocknet deadline noop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,3 +106,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
+
+replace github.com/libp2p/go-libp2p => github.com/celestiaorg/go-libp2p v0.0.0-20260227132409-ca1f74a6feb6

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/celestiaorg/go-libp2p v0.0.0-20260227132409-ca1f74a6feb6 h1:GS5xo6iebu9WUaWMrLX1xgLXqkRM5bKcryEjPgge+fk=
+github.com/celestiaorg/go-libp2p v0.0.0-20260227132409-ca1f74a6feb6/go.mod h1:TbIDnpDjBLa7isdgYpbxozIVPBTmM/7qKOJP4SFySrQ=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -63,8 +65,6 @@ github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/libp2p/go-flow-metrics v0.2.0 h1:EIZzjmeOE6c8Dav0sNv35vhZxATIXWZg6j/C08XmmDw=
 github.com/libp2p/go-flow-metrics v0.2.0/go.mod h1:st3qqfu8+pMfh+9Mzqb2GTiwrAGjIPszEjZmtksN8Jc=
-github.com/libp2p/go-libp2p v0.46.0 h1:0T2yvIKpZ3DVYCuPOFxPD1layhRU486pj9rSlGWYnDM=
-github.com/libp2p/go-libp2p v0.46.0/go.mod h1:TbIDnpDjBLa7isdgYpbxozIVPBTmM/7qKOJP4SFySrQ=
 github.com/libp2p/go-libp2p-asn-util v0.4.1 h1:xqL7++IKD9TBFMgnLPZR6/6iYhawHKHl950SO9L6n94=
 github.com/libp2p/go-libp2p-asn-util v0.4.1/go.mod h1:d/NI6XZ9qxw67b4e+NgpQexCIiFYJjErASrYW4PFDN8=
 github.com/libp2p/go-libp2p-pubsub v0.15.0 h1:cG7Cng2BT82WttmPFMi50gDNV+58K626m/wR00vGL1o=


### PR DESCRIPTION
## Summary
- Replace `github.com/libp2p/go-libp2p` with `github.com/celestiaorg/go-libp2p` fork based on v0.46.0
- The fork makes `SetDeadline`, `SetReadDeadline`, and `SetWriteDeadline` return nil on mocknet streams instead of an error

## Context
go-libp2p-pubsub added `SetWriteDeadline` calls in [libp2p/go-libp2p-pubsub@6587e8e](https://github.com/libp2p/go-libp2p-pubsub/commit/6587e8e72b35957a53d61dcf91f05b1b9a78bfdf) (part of https://github.com/libp2p/go-libp2p-pubsub/pull/631). Mocknet streams use `io.Pipe` which doesn't support deadlines, so `SetWriteDeadline` returns an error. The pubsub code treats this as fatal — resets the stream and never sends the hello packet. This prevents gossipsub peers from discovering each other's subscriptions in any mocknet-based test.

Upstream PR: https://github.com/libp2p/go-libp2p/pull/new/fix/mocknet-deadline-noop