### PR TITLE
fix(p2p): propagate `SoftFailure` error from `Exchange.Head` to caller

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -117,5 +117,9 @@ type Getter[H Header[H]] interface {
 // reporting it.
 type Head[H Header[H]] interface {
 	// Head returns the latest known header.
+	//
+	// If a TrustedHead option is provided and the returned header fails
+	// verification against it with a SoftFailure, implementations MUST return
+	// both the header and the *VerifyError so callers can attempt bifurcation.
 	Head(context.Context, ...HeadOption[H]) (H, error)
 }

--- a/p2p/exchange.go
+++ b/p2p/exchange.go
@@ -156,13 +156,18 @@ func (ex *Exchange[H]) Head(ctx context.Context, opts ...header.HeadOption[H]) (
 		}
 	}
 
+	type headResp struct {
+		h       H
+		softErr error
+	}
+
 	var (
 		zero      H
 		headerReq = &p2p_pb.HeaderRequest{
 			Data:   &p2p_pb.HeaderRequest_Origin{Origin: uint64(0)},
 			Amount: 1,
 		}
-		headerRespCh = make(chan H, len(peers))
+		headerRespCh = make(chan headResp, len(peers))
 	)
 	for _, from := range peers {
 		go func(from peer.ID) {
@@ -176,7 +181,7 @@ func (ex *Exchange[H]) Head(ctx context.Context, opts ...header.HeadOption[H]) (
 			if err != nil {
 				newSpan.SetStatus(codes.Error, err.Error())
 				log.Errorw("head request to peer failed", "peer", from, "err", err)
-				headerRespCh <- zero
+				headerRespCh <- headResp{h: zero}
 				return
 			}
 			// if tracked (untrusted) peers were requested, verify head
@@ -188,7 +193,7 @@ func (ex *Exchange[H]) Head(ctx context.Context, opts ...header.HeadOption[H]) (
 						log.Debugw("received head from tracked peer that soft-failed verification",
 							"tracked peer", from, "err", err)
 						newSpan.SetStatus(codes.Error, err.Error())
-						headerRespCh <- headers[0]
+						headerRespCh <- headResp{h: headers[0], softErr: err}
 						return
 					}
 					logF := log.Warnw
@@ -198,13 +203,13 @@ func (ex *Exchange[H]) Head(ctx context.Context, opts ...header.HeadOption[H]) (
 					logF("verifying head received from tracked peer", "tracked peer", from,
 						"height", headers[0].Height(), "err", err)
 					newSpan.SetStatus(codes.Error, err.Error())
-					headerRespCh <- zero
+					headerRespCh <- headResp{h: zero}
 					return
 				}
 			}
 			newSpan.SetStatus(codes.Ok, "")
 			// request ensures that the result slice will have at least one Header
-			headerRespCh <- headers[0]
+			headerRespCh <- headResp{h: headers[0]}
 		}(from)
 	}
 
@@ -215,12 +220,16 @@ func (ex *Exchange[H]) Head(ctx context.Context, opts ...header.HeadOption[H]) (
 
 	headers := make([]H, 0, len(peers))
 	counter := make(map[string]int)
+	softErrs := make(map[string]error)
 	for range peers {
 		select {
-		case h := <-headerRespCh:
-			if !h.IsZero() {
-				headers = append(headers, h)
-				hash := h.Hash().String()
+		case res := <-headerRespCh:
+			if !res.h.IsZero() {
+				headers = append(headers, res.h)
+				hash := res.h.Hash().String()
+				if res.softErr != nil {
+					softErrs[hash] = res.softErr
+				}
 				counter[hash]++
 				if counter[hash] >= minHeadResponses(len(peers)) {
 					reqCancel()
@@ -228,7 +237,7 @@ func (ex *Exchange[H]) Head(ctx context.Context, opts ...header.HeadOption[H]) (
 						ctx, time.Since(startTime), len(headers), headType, headStatusOk,
 					)
 					span.SetStatus(codes.Ok, "")
-					return h, nil
+					return res.h, softErrs[hash]
 				}
 			}
 		case <-ctx.Done():
@@ -258,7 +267,7 @@ func (ex *Exchange[H]) Head(ctx context.Context, opts ...header.HeadOption[H]) (
 	log.Debug("could not find head confirmed by two peers, returning highest")
 	ex.metrics.head(ctx, time.Since(startTime), len(headers), headType, headStatusOk)
 	span.SetStatus(codes.Ok, "")
-	return headers[0], nil
+	return headers[0], softErrs[headers[0].Hash().String()]
 }
 
 // GetByHeight performs a request for the Header at the given

--- a/p2p/exchange_test.go
+++ b/p2p/exchange_test.go
@@ -125,9 +125,11 @@ func TestExchange_RequestHead_SoftFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// now use that trusted head to request a new head from the exchange
-	// from the tracked peer
+	// from the tracked peer — expect the header back alongside a SoftFailure error
 	softFailHead, err := exchg.Head(ctx, header.WithTrustedHead[*headertest.DummyHeader](head))
-	require.NoError(t, err)
+	var verErr *header.VerifyError
+	require.ErrorAs(t, err, &verErr)
+	require.True(t, verErr.SoftFailure)
 	assert.Equal(t, trackedStore.HeadHeight, softFailHead.Height())
 }
 


### PR DESCRIPTION
`p2p.Exchange.Head` was sending soft-failed headers to the response channel without the accompanying *VerifyError, causing the Syncer to never attempt bifurcation for those headers.

Fix by carrying both the header and a soft error through the response channel using a local headResp type. A softErrs map tracks the error per hash so both the early-consensus and highest-wins return paths propagate it correctly.

Document the contract on Head[H]: implementations must return (header, *VerifyError{SoftFailure: true}) together when TrustedHead verification soft-fails.

Update TestExchange_RequestHead_SoftFailure to assert the error IS returned.

Close https://linear.app/celestia/issue/PROTOCO-1324/handle-celestia-237