### PR TITLE
fix(sync): re-verify pending headers against stored predecessor

### DIFF
--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -331,6 +331,20 @@ func (s *Syncer[H]) processHeaders(
 			}
 		}
 
+		// Defense-in-depth: re-verify pending headers against the immediately
+		// preceding (just-stored) header before appending. Pending headers were
+		// admitted via incomingNetworkHead, which verifies against the subjective
+		// head and may rely on bifurcation for non-adjacent verification. That
+		// does not guarantee each pending header is valid against its direct
+		// predecessor, so we verify the adjacent chain here.
+		if _, err := header.VerifyRange(fromHead, headers); err != nil {
+			log.Errorw("verifying pending headers against predecessor",
+				"from_height", fromHead.Height(),
+				"from_hash", fromHead.Hash(),
+				"err", err)
+			return err
+		}
+
 		// apply cached headers
 		if err := s.store.Append(ctx, headers...); err != nil {
 			return err

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -286,6 +286,50 @@ func TestSyncer_FindHeadersReturnsCorrectRange(t *testing.T) {
 	assert.Equal(t, head.Height(), uint64(21))
 }
 
+// TestSyncer_ProcessHeadersRejectsInvalidPendingChain ensures that processHeaders
+// re-verifies pending headers against their immediately preceding (stored) header
+// before appending them to the store. A pending header that fails verification
+// against its predecessor must not be stored and processHeaders must return an error.
+func TestSyncer_ProcessHeadersRejectsInvalidPendingChain(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+
+	remoteStore := newTestStore(t, ctx, head)
+	localStore := newTestStore(t, ctx, head)
+	syncer, err := NewSyncer(
+		local.NewExchange(remoteStore),
+		localStore,
+		headertest.NewDummySubscriber(),
+	)
+	require.NoError(t, err)
+
+	// build a malicious header at head.Height()+1 that should fail verification
+	// against the stored head. The header's height is adjacent so the store's
+	// adjacency-by-height check passes, but its Verify against head must fail.
+	malicious := suite.NextHeader()
+	malicious.VerifyFailure = true
+
+	// inject the malicious header into the pending cache directly to simulate
+	// the case where a header bypassed upstream validation.
+	syncer.pending.Add(malicious)
+
+	// processHeaders must reject the malicious header
+	err = syncer.processHeaders(ctx, head, malicious.Height())
+	require.Error(t, err)
+
+	// the malicious header must NOT be stored
+	require.False(t, localStore.HasAt(ctx, malicious.Height()),
+		"malicious header was stored despite failing verification")
+
+	// store head must remain the initial head
+	storeHead, err := localStore.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, head.Height(), storeHead.Height())
+}
+
 func TestSyncerIncomingDuplicate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)


### PR DESCRIPTION
## Summary

Adds adjacent re-verification of pending headers in `sync.Syncer.processHeaders` before they are appended to the store.

Pending headers are admitted via `incomingNetworkHead`, which verifies against the subjective head and may rely on bifurcation for non-adjacent verification. That does not guarantee each pending header is valid against its direct predecessor, so we now call `header.VerifyRange(fromHead, headers)` on the pending batch immediately before `store.Append`.

Defense-in-depth: prevents a malicious header from being persisted if it bypasses upstream validation by other means.

Closes [PROTOCO-1743](https://linear.app/celestia/issue/PROTOCO-1743)

## Test plan

- [x] New unit test `TestSyncer_ProcessHeadersRejectsInvalidPendingChain` injects a pending header that fails `Verify` against its predecessor, asserts `processHeaders` returns an error, and asserts the malicious header is not stored.
- [x] `go test ./...` passes (no regressions).
- [x] `go test -race ./sync/` passes for the affected tests (pre-existing tail-sync races on `main` are unrelated).