### PR TITLE
feat!(sync): support contiguous partial ranges from getter

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -109,6 +109,12 @@ type Getter[H Header[H]] interface {
 	// GetRangeByHeight requests the header range from the provided Header and
 	// verifies that the returned headers are adjacent to each other.
 	// Expected to return the range [from.Height()+1:to).
+	//
+	// Implementations MAY return a non-empty CONTIGUOUS PREFIX of the requested
+	// range together with a nil error. The returned headers MUST start at
+	// from.Height()+1 and be adjacent to each other. Gaps within the response
+	// are not allowed; if a getter cannot produce a contiguous prefix, it MUST
+	// return an error instead of an empty or sparse slice.
 	GetRangeByHeight(ctx context.Context, from H, to uint64) ([]H, error)
 }
 

--- a/interface.go
+++ b/interface.go
@@ -110,11 +110,9 @@ type Getter[H Header[H]] interface {
 	// verifies that the returned headers are adjacent to each other.
 	// Expected to return the range [from.Height()+1:to).
 	//
-	// Implementations MAY return a non-empty CONTIGUOUS PREFIX of the requested
-	// range together with a nil error. The returned headers MUST start at
-	// from.Height()+1 and be adjacent to each other. Gaps within the response
-	// are not allowed; if a getter cannot produce a contiguous prefix, it MUST
-	// return an error instead of an empty or sparse slice.
+	// Implementations MAY return a non-empty contiguous prefix of the range
+	// (starting at from.Height()+1, no gaps) with a nil error, otherwise they
+	// MUST return an error rather than an empty or sparse slice.
 	GetRangeByHeight(ctx context.Context, from H, to uint64) ([]H, error)
 }
 

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -345,11 +345,8 @@ func (s *Syncer[H]) processHeaders(
 }
 
 // requestHeaders requests headers from the network -> (fromHeader.Height : to].
-//
-// The getter may return a contiguous prefix shorter than requested (see
-// Getter.GetRangeByHeight). In that case we advance fromHead by the actual
-// number of headers received and continue requesting the remainder in the
-// next iteration.
+// The getter may return a contiguous prefix shorter than requested, in which
+// case the remainder is requested in the next iteration.
 func (s *Syncer[H]) requestHeaders(
 	ctx context.Context,
 	fromHead H,
@@ -374,7 +371,7 @@ func (s *Syncer[H]) requestHeaders(
 				fromHead.Height(), reqTo)
 		}
 		if headers[0].Height() != fromHead.Height()+1 {
-			return fmt.Errorf("syncer: getter returned non-adjacent range, expected first header at %d, got %d",
+			return fmt.Errorf("syncer: getter returned non-adjacent range: want %d, got %d",
 				fromHead.Height()+1, headers[0].Height())
 		}
 
@@ -383,9 +380,8 @@ func (s *Syncer[H]) requestHeaders(
 		}
 
 		if uint64(len(headers)) < size {
-			log.Debugw("partial range received, will continue from last received header",
-				"requested", size, "received", len(headers),
-				"from", fromHead.Height(), "to", reqTo)
+			log.Debugw("partial range received, continuing from last received header",
+				"requested up to", reqTo, "received", headers[len(headers)-1].Height())
 		}
 		fromHead = headers[len(headers)-1]
 	}

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -345,32 +345,48 @@ func (s *Syncer[H]) processHeaders(
 }
 
 // requestHeaders requests headers from the network -> (fromHeader.Height : to].
+//
+// The getter may return a contiguous prefix shorter than requested (see
+// Getter.GetRangeByHeight). In that case we advance fromHead by the actual
+// number of headers received and continue requesting the remainder in the
+// next iteration.
 func (s *Syncer[H]) requestHeaders(
 	ctx context.Context,
 	fromHead H,
 	to uint64,
 ) error {
-	amount := to - fromHead.Height()
-	// start requesting headers until amount remaining will be 0
-	for amount > 0 {
+	for fromHead.Height() < to {
+		amount := to - fromHead.Height()
 		size := header.MaxRangeRequestSize
 		if amount < size {
 			size = amount
 		}
 
-		to := fromHead.Height() + size + 1
+		reqTo := fromHead.Height() + size + 1
 		start := time.Now()
-		headers, err := s.getter.GetRangeByHeight(ctx, fromHead, to)
+		headers, err := s.getter.GetRangeByHeight(ctx, fromHead, reqTo)
 		s.metrics.recordRangeRequest(ctx, time.Since(start), size)
 		if err != nil {
 			return err
+		}
+		if len(headers) == 0 {
+			return fmt.Errorf("syncer: getter returned empty range for (%d:%d)",
+				fromHead.Height(), reqTo)
+		}
+		if headers[0].Height() != fromHead.Height()+1 {
+			return fmt.Errorf("syncer: getter returned non-adjacent range, expected first header at %d, got %d",
+				fromHead.Height()+1, headers[0].Height())
 		}
 
 		if err := s.store.Append(ctx, headers...); err != nil {
 			return err
 		}
 
-		amount -= size // size == len(headers)
+		if uint64(len(headers)) < size {
+			log.Debugw("partial range received, will continue from last received header",
+				"requested", size, "received", len(headers),
+				"from", fromHead.Height(), "to", reqTo)
+		}
 		fromHead = headers[len(headers)-1]
 	}
 	return nil

--- a/sync/syncer_partial_test.go
+++ b/sync/syncer_partial_test.go
@@ -14,19 +14,13 @@ import (
 	"github.com/celestiaorg/go-header/local"
 )
 
-// partialGetter wraps an underlying Getter and truncates GetRangeByHeight
-// responses to simulate a peer that returns a contiguous prefix of the
-// requested range with a nil error.
+// partialGetter truncates GetRangeByHeight responses to simulate a peer that
+// returns a contiguous prefix of the requested range.
 type partialGetter[H header.Header[H]] struct {
 	header.Getter[H]
-	// truncateTo limits the number of headers returned per call.
-	// If 0, returns the full range. If headers returned exceed truncateTo,
-	// only the first truncateTo are returned.
 	truncateTo int
-	// emptyOnce, if true, makes the first call return an empty slice with
-	// nil error (a contract violation we want to test the syncer rejects).
-	emptyOnce atomic.Bool
-	calls     atomic.Int32
+	emptyOnce  atomic.Bool
+	calls      atomic.Int32
 }
 
 func (p *partialGetter[H]) GetRangeByHeight(ctx context.Context, from H, to uint64) ([]H, error) {
@@ -46,10 +40,8 @@ func (p *partialGetter[H]) GetRangeByHeight(ctx context.Context, from H, to uint
 	return headers, nil
 }
 
-// TestSyncer_PartialRangeTail simulates a peer that consistently returns
-// fewer headers than requested (e.g. peer is itself catching up).
-// The syncer must keep requesting the remainder until it reaches the target,
-// without skipping any headers.
+// TestSyncer_PartialRangeTail: a getter that always returns fewer headers than
+// requested must still let the syncer reach the target without skipping any.
 func TestSyncer_PartialRangeTail(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)
@@ -91,9 +83,8 @@ func TestSyncer_PartialRangeTail(t *testing.T) {
 	assert.GreaterOrEqual(t, int(getter.calls.Load()), minCalls)
 }
 
-// TestSyncer_PartialRangeMidRequest checks that when the partial happens
-// mid-way (after several full-size responses), the syncer still advances
-// correctly and reaches the target without skipping headers.
+// TestSyncer_PartialRangeMidRequest: a partial response mid-way (after several
+// full-size ones) must not make the syncer skip headers.
 func TestSyncer_PartialRangeMidRequest(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)
@@ -109,7 +100,11 @@ func TestSyncer_PartialRangeMidRequest(t *testing.T) {
 	// truncate only the second batch to a small prefix
 	var calls atomic.Int32
 	getter := wrapGetterFunc(local.NewExchange(remoteStore),
-		func(ctx context.Context, from *headertest.DummyHeader, to uint64) ([]*headertest.DummyHeader, error) {
+		func(
+			ctx context.Context,
+			from *headertest.DummyHeader,
+			to uint64,
+		) ([]*headertest.DummyHeader, error) {
 			n := calls.Add(1)
 			headers, err := local.NewExchange(remoteStore).GetRangeByHeight(ctx, from, to)
 			if err != nil {
@@ -140,9 +135,8 @@ func TestSyncer_PartialRangeMidRequest(t *testing.T) {
 	assert.Equal(t, head.Height()+uint64(total), gotHead.Height())
 }
 
-// TestSyncer_PartialRangeEmptyReturnsError checks that a getter which
-// violates the contract by returning an empty slice with nil error is
-// rejected with an error, rather than panicking.
+// TestSyncer_PartialRangeEmptyReturnsError: an empty slice with a nil error
+// (contract violation) must be rejected, not panic.
 func TestSyncer_PartialRangeEmptyReturnsError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)
@@ -173,9 +167,8 @@ func TestSyncer_PartialRangeEmptyReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "empty range")
 }
 
-// TestSyncer_PartialRangeNonAdjacentReturnsError checks that a getter which
-// violates the contract by returning headers that don't start at
-// fromHead.Height()+1 is rejected with an error.
+// TestSyncer_PartialRangeNonAdjacentReturnsError: a range not starting at
+// fromHead.Height()+1 (contract violation) must be rejected.
 func TestSyncer_PartialRangeNonAdjacentReturnsError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	t.Cleanup(cancel)
@@ -187,7 +180,11 @@ func TestSyncer_PartialRangeNonAdjacentReturnsError(t *testing.T) {
 	require.NoError(t, remoteStore.Append(ctx, suite.GenDummyHeaders(10)...))
 
 	getter := wrapGetterFunc(local.NewExchange(remoteStore),
-		func(ctx context.Context, from *headertest.DummyHeader, to uint64) ([]*headertest.DummyHeader, error) {
+		func(
+			ctx context.Context,
+			from *headertest.DummyHeader,
+			to uint64,
+		) ([]*headertest.DummyHeader, error) {
 			headers, err := local.NewExchange(remoteStore).GetRangeByHeight(ctx, from, to)
 			if err != nil {
 				return nil, err
@@ -215,8 +212,7 @@ func TestSyncer_PartialRangeNonAdjacentReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "non-adjacent")
 }
 
-// getterFunc adapts a function into a header.Getter by delegating Head/Get/GetByHeight
-// to an underlying getter while overriding GetRangeByHeight.
+// getterFunc overrides GetRangeByHeight on an underlying Getter with fn.
 type getterFunc[H header.Header[H]] struct {
 	header.Getter[H]
 	fn func(ctx context.Context, from H, to uint64) ([]H, error)

--- a/sync/syncer_partial_test.go
+++ b/sync/syncer_partial_test.go
@@ -1,0 +1,234 @@
+package sync
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/go-header"
+	"github.com/celestiaorg/go-header/headertest"
+	"github.com/celestiaorg/go-header/local"
+)
+
+// partialGetter wraps an underlying Getter and truncates GetRangeByHeight
+// responses to simulate a peer that returns a contiguous prefix of the
+// requested range with a nil error.
+type partialGetter[H header.Header[H]] struct {
+	header.Getter[H]
+	// truncateTo limits the number of headers returned per call.
+	// If 0, returns the full range. If headers returned exceed truncateTo,
+	// only the first truncateTo are returned.
+	truncateTo int
+	// emptyOnce, if true, makes the first call return an empty slice with
+	// nil error (a contract violation we want to test the syncer rejects).
+	emptyOnce atomic.Bool
+	calls     atomic.Int32
+}
+
+func (p *partialGetter[H]) GetRangeByHeight(ctx context.Context, from H, to uint64) ([]H, error) {
+	p.calls.Add(1)
+	if p.emptyOnce.Load() {
+		p.emptyOnce.Store(false)
+		var empty []H
+		return empty, nil
+	}
+	headers, err := p.Getter.GetRangeByHeight(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+	if p.truncateTo > 0 && len(headers) > p.truncateTo {
+		return headers[:p.truncateTo], nil
+	}
+	return headers, nil
+}
+
+// TestSyncer_PartialRangeTail simulates a peer that consistently returns
+// fewer headers than requested (e.g. peer is itself catching up).
+// The syncer must keep requesting the remainder until it reaches the target,
+// without skipping any headers.
+func TestSyncer_PartialRangeTail(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+
+	remoteStore := newTestStore(t, ctx, head)
+	const total = 50
+	require.NoError(t, remoteStore.Append(ctx, suite.GenDummyHeaders(total)...))
+
+	const truncate = 7
+	getter := &partialGetter[*headertest.DummyHeader]{
+		Getter:     local.NewExchange(remoteStore),
+		truncateTo: truncate,
+	}
+
+	localStore := newTestStore(t, ctx, head)
+	syncer, err := NewSyncer(
+		getter,
+		localStore,
+		headertest.NewDummySubscriber(),
+		WithBlockTime(time.Nanosecond),
+		WithRecencyThreshold(time.Nanosecond),
+	)
+	require.NoError(t, err)
+
+	// drive requestHeaders directly to keep the test deterministic
+	err = syncer.requestHeaders(ctx, head, head.Height()+total)
+	require.NoError(t, err)
+
+	// GetByHeight blocks via heightSub until the height is observed.
+	gotHead, err := localStore.GetByHeight(ctx, head.Height()+total)
+	require.NoError(t, err)
+	assert.Equal(t, head.Height()+total, gotHead.Height())
+
+	// at least ceil(total/truncate) calls must have been made
+	minCalls := (total + truncate - 1) / truncate
+	assert.GreaterOrEqual(t, int(getter.calls.Load()), minCalls)
+}
+
+// TestSyncer_PartialRangeMidRequest checks that when the partial happens
+// mid-way (after several full-size responses), the syncer still advances
+// correctly and reaches the target without skipping headers.
+func TestSyncer_PartialRangeMidRequest(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+
+	remoteStore := newTestStore(t, ctx, head)
+	// use a size > MaxRangeRequestSize to ensure the syncer paginates
+	total := int(header.MaxRangeRequestSize) + 30
+	require.NoError(t, remoteStore.Append(ctx, suite.GenDummyHeaders(total)...))
+
+	// truncate only the second batch to a small prefix
+	var calls atomic.Int32
+	getter := wrapGetterFunc(local.NewExchange(remoteStore),
+		func(ctx context.Context, from *headertest.DummyHeader, to uint64) ([]*headertest.DummyHeader, error) {
+			n := calls.Add(1)
+			headers, err := local.NewExchange(remoteStore).GetRangeByHeight(ctx, from, to)
+			if err != nil {
+				return nil, err
+			}
+			if n == 2 && len(headers) > 5 {
+				return headers[:5], nil
+			}
+			return headers, nil
+		},
+	)
+
+	localStore := newTestStore(t, ctx, head)
+	syncer, err := NewSyncer(
+		getter,
+		localStore,
+		headertest.NewDummySubscriber(),
+		WithBlockTime(time.Nanosecond),
+		WithRecencyThreshold(time.Nanosecond),
+	)
+	require.NoError(t, err)
+
+	err = syncer.requestHeaders(ctx, head, head.Height()+uint64(total))
+	require.NoError(t, err)
+
+	gotHead, err := localStore.GetByHeight(ctx, head.Height()+uint64(total))
+	require.NoError(t, err)
+	assert.Equal(t, head.Height()+uint64(total), gotHead.Height())
+}
+
+// TestSyncer_PartialRangeEmptyReturnsError checks that a getter which
+// violates the contract by returning an empty slice with nil error is
+// rejected with an error, rather than panicking.
+func TestSyncer_PartialRangeEmptyReturnsError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+
+	remoteStore := newTestStore(t, ctx, head)
+	require.NoError(t, remoteStore.Append(ctx, suite.GenDummyHeaders(10)...))
+
+	getter := &partialGetter[*headertest.DummyHeader]{
+		Getter: local.NewExchange(remoteStore),
+	}
+	getter.emptyOnce.Store(true)
+
+	localStore := newTestStore(t, ctx, head)
+	syncer, err := NewSyncer(
+		getter,
+		localStore,
+		headertest.NewDummySubscriber(),
+		WithBlockTime(time.Nanosecond),
+		WithRecencyThreshold(time.Nanosecond),
+	)
+	require.NoError(t, err)
+
+	err = syncer.requestHeaders(ctx, head, head.Height()+10)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty range")
+}
+
+// TestSyncer_PartialRangeNonAdjacentReturnsError checks that a getter which
+// violates the contract by returning headers that don't start at
+// fromHead.Height()+1 is rejected with an error.
+func TestSyncer_PartialRangeNonAdjacentReturnsError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+
+	remoteStore := newTestStore(t, ctx, head)
+	require.NoError(t, remoteStore.Append(ctx, suite.GenDummyHeaders(10)...))
+
+	getter := wrapGetterFunc(local.NewExchange(remoteStore),
+		func(ctx context.Context, from *headertest.DummyHeader, to uint64) ([]*headertest.DummyHeader, error) {
+			headers, err := local.NewExchange(remoteStore).GetRangeByHeight(ctx, from, to)
+			if err != nil {
+				return nil, err
+			}
+			if len(headers) > 1 {
+				// drop the first header to create a gap from fromHead
+				return headers[1:], nil
+			}
+			return headers, nil
+		},
+	)
+
+	localStore := newTestStore(t, ctx, head)
+	syncer, err := NewSyncer(
+		getter,
+		localStore,
+		headertest.NewDummySubscriber(),
+		WithBlockTime(time.Nanosecond),
+		WithRecencyThreshold(time.Nanosecond),
+	)
+	require.NoError(t, err)
+
+	err = syncer.requestHeaders(ctx, head, head.Height()+10)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-adjacent")
+}
+
+// getterFunc adapts a function into a header.Getter by delegating Head/Get/GetByHeight
+// to an underlying getter while overriding GetRangeByHeight.
+type getterFunc[H header.Header[H]] struct {
+	header.Getter[H]
+	fn func(ctx context.Context, from H, to uint64) ([]H, error)
+}
+
+func wrapGetterFunc[H header.Header[H]](
+	inner header.Getter[H],
+	fn func(ctx context.Context, from H, to uint64) ([]H, error),
+) header.Getter[H] {
+	return &getterFunc[H]{Getter: inner, fn: fn}
+}
+
+func (g *getterFunc[H]) GetRangeByHeight(ctx context.Context, from H, to uint64) ([]H, error) {
+	return g.fn(ctx, from, to)
+}


### PR DESCRIPTION
  Formalizes partial-range responses in the `Getter.GetRangeByHeight` contract                                                                             
  and fixes a latent bug in `Syncer.requestHeaders` that caused the syncer to                                                                              
  silently advance past the target when a getter returned fewer headers than                                                                               
  requested.                                                                                                                                               
   
  Previously `requestHeaders` assumed `len(headers) == size` on every call:                                                                                
                                                                                                                                                         
  ```go                                                                                                                                                    
  amount -= size // size == len(headers)                                                                                                                   
  fromHead = headers[len(headers)-1]
```
                                                                                                                                                           
  A getter returning a contiguous prefix shorter than requested (e.g. peer                                                                               
  still catching up, transient mid-range failure) would still see amount
  decremented by the requested size, so the outer loop exits with fromHead                                                                                 
  behind to — the missed range would only be re-fetched on the next sync
  cycle, if at all.                                                                                                                                        
                                                                                                                                                           
  Surfaced in                                                                                                                                              
  celestiaorg/celestia-node#4738 (review comment) — that PR adds partial-range                                                                             
  support on the celestia-node side and relies on go-header handling it                                                                                    
  correctly.
