### PR TITLE
fix(sync): harden syncer lifecycle

### DIFF
--- a/sync/metrics.go
+++ b/sync/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 var meter = otel.Meter("header/sync")
 
 type metrics struct {
+	mu        sync.Mutex
 	syncerReg metric.Registration
 
 	trustedPeersOutOfSync metric.Int64Counter
@@ -103,15 +105,33 @@ func newMetrics() (*metrics, error) {
 		subjectiveHeadInst:    subjectiveHead,
 	}
 
-	m.syncerReg, err = meter.RegisterCallback(
-		m.observeMetrics,
-		m.subjectiveHeadInst,
-	)
-	if err != nil {
+	if err := m.Start(); err != nil {
 		return nil, err
 	}
 
 	return m, nil
+}
+
+func (m *metrics) Start() error {
+	if m == nil {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.syncerReg != nil {
+		return nil
+	}
+
+	reg, err := meter.RegisterCallback(
+		m.observeMetrics,
+		m.subjectiveHeadInst,
+	)
+	if err != nil {
+		return err
+	}
+	m.syncerReg = reg
+	return nil
 }
 
 func (m *metrics) observeMetrics(_ context.Context, obs metric.Observer) error {
@@ -200,5 +220,14 @@ func (m *metrics) Close() error {
 	if m == nil {
 		return nil
 	}
-	return m.syncerReg.Unregister()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.syncerReg == nil {
+		return nil
+	}
+
+	err := m.syncerReg.Unregister()
+	m.syncerReg = nil
+	return err
 }

--- a/sync/sync_lifecycle.go
+++ b/sync/sync_lifecycle.go
@@ -1,0 +1,212 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	// ErrSyncerStarting is returned when Start is called while another Start is in progress.
+	ErrSyncerStarting = errors.New("sync: syncer is starting")
+	// ErrSyncerRunning is returned when Start is called on a running Syncer.
+	ErrSyncerRunning = errors.New("sync: syncer is already running")
+	// ErrSyncerStopping is returned when Start is called before the current Stop completes.
+	ErrSyncerStopping = errors.New("sync: syncer is stopping")
+)
+
+type lifecycleState uint8
+
+const (
+	stateStopped lifecycleState = iota
+	stateStarting
+	stateRunning
+	stateStopping
+)
+
+// syncRun owns every resource whose lifetime is limited to one Start/Stop cycle.
+// A goroutine must retain its run pointer instead of reloading s.run, because a
+// later Start may install a different run before an older caller finishes.
+type syncRun struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{}
+	err    error
+	finish sync.Once
+}
+
+// Lifecycle invariants:
+//   - stateStopped implies run == nil.
+//   - Every other state implies run != nil.
+//   - At most one run may be starting, running, or stopping at a time.
+//   - Only the owner of a run closes run.done.
+//   - run.done is closed after the Syncer has published stateStopped.
+//   - Stop cancellation is idempotent; completion is observed through run.done.
+
+// Start initializes and starts one synchronization run. It returns a lifecycle
+// error if another run is starting, running, or stopping. Canceling ctx cancels
+// initialization and guarantees that no sync loop is left running.
+func (s *Syncer[H]) Start(ctx context.Context) error {
+	run, err := s.beginStart()
+	if err != nil {
+		return err
+	}
+
+	// A canceled Start must not leave initialization running in the background.
+	stopCallerCancel := context.AfterFunc(ctx, run.cancel)
+	defer stopCallerCancel()
+
+	if err := s.metrics.Start(); err != nil {
+		s.finishRun(run)
+		return fmt.Errorf("starting metrics: %w", err)
+	}
+
+	if err := s.installVerifier(); err != nil {
+		s.finishRun(run)
+		return err
+	}
+
+	if _, err := s.Head(run.ctx); err != nil {
+		s.finishRun(run)
+		return fmt.Errorf("error getting latest head during Start: %w", err)
+	}
+
+	// Stop the caller-cancellation callback before publishing a running service.
+	// If it already fired, this run was canceled and must not start its loop.
+	if !stopCallerCancel() || ctx.Err() != nil || run.ctx.Err() != nil {
+		s.finishRun(run)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return run.ctx.Err()
+	}
+
+	s.lifecycleMu.Lock()
+	if s.run != run || s.lifecycleState != stateStarting {
+		s.lifecycleMu.Unlock()
+		s.finishRun(run)
+		return context.Canceled
+	}
+	s.lifecycleState = stateRunning
+	s.lifecycleMu.Unlock()
+
+	go s.runSyncLoop(run)
+	s.signalStarted()
+	return nil
+}
+
+func (s *Syncer[H]) beginStart() (*syncRun, error) {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+
+	switch s.lifecycleState {
+	case stateStarting:
+		return nil, ErrSyncerStarting
+	case stateRunning:
+		return nil, ErrSyncerRunning
+	case stateStopping:
+		return nil, ErrSyncerStopping
+	case stateStopped:
+	}
+
+	//nolint:gosec // G118: run.cancel is called by Stop or finishRun.
+	runCtx, runCancel := context.WithCancel(context.Background())
+	run := &syncRun{
+		ctx:    runCtx,
+		cancel: runCancel,
+		done:   make(chan struct{}),
+	}
+	s.run = run
+	s.lifecycleState = stateStarting
+	return run, nil
+}
+
+// Stop requests cancellation and waits for the current run to finish. Stop is
+// idempotent when the Syncer is stopped and safe for concurrent callers. If ctx
+// expires, the run remains in stateStopping and continues its cleanup; a later
+// Stop call may wait on the same run.
+func (s *Syncer[H]) Stop(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	if s.lifecycleState == stateStopped {
+		s.lifecycleMu.Unlock()
+		return nil
+	}
+
+	run := s.run
+	s.lifecycleState = stateStopping
+	s.lifecycleMu.Unlock()
+
+	run.cancel()
+	select {
+	case <-run.done:
+		return run.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Syncer[H]) runSyncLoop(run *syncRun) {
+	defer s.finishRun(run)
+	s.syncLoop(run.ctx)
+}
+
+// finishRun is the single completion path for both failed starts and running
+// loops. The identity check prevents an obsolete run from clearing newer state.
+func (s *Syncer[H]) finishRun(run *syncRun) {
+	run.finish.Do(func() {
+		run.cancel()
+		run.err = s.metrics.Close()
+
+		s.lifecycleMu.Lock()
+		if s.run == run {
+			s.run = nil
+			s.lifecycleState = stateStopped
+		}
+		s.lifecycleMu.Unlock()
+
+		close(run.done)
+	})
+}
+
+func (s *Syncer[H]) installVerifier() error {
+	s.verifierMu.Lock()
+	defer s.verifierMu.Unlock()
+	if s.verifierInstalled {
+		return nil
+	}
+
+	// The verifier belongs to the Syncer instance, not to an individual run.
+	// Subscriber implementations allow it to be installed only once.
+	err := s.sub.SetVerifier(func(ctx context.Context, h H) error {
+		// During subjective initialization Head is requested before Tail is stored.
+		// Stall subscription delivery until the first successful Start closes started.
+		select {
+		case <-s.started:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		if err := s.incomingNetworkHead(ctx, h); err != nil {
+			return err
+		}
+		if _, err := s.subjectiveTail(ctx, h); err != nil {
+			log.Errorw("subjective tail", "head", h.Height(), "err", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("installing subscriber verifier: %w", err)
+	}
+
+	s.verifierInstalled = true
+	return nil
+}
+
+func (s *Syncer[H]) signalStarted() {
+	select {
+	case <-s.started:
+	default:
+		close(s.started)
+	}
+}

--- a/sync/sync_lifecycle_test.go
+++ b/sync/sync_lifecycle_test.go
@@ -1,0 +1,380 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/go-header"
+	"github.com/celestiaorg/go-header/headertest"
+	"github.com/celestiaorg/go-header/local"
+)
+
+func TestSyncer_StopWaitsForSyncLoop(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+	localStore := newTestStore(t, ctx, head)
+	remoteStore := headertest.NewStore(t, suite, 100)
+	getter := &blockingGetter[*headertest.DummyHeader]{
+		Getter:   local.NewExchange(remoteStore),
+		entered:  make(chan struct{}),
+		canceled: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	t.Cleanup(func() { closeOnce(getter.release) })
+
+	syncer, err := NewSyncer(
+		getter,
+		localStore,
+		headertest.NewDummySubscriber(),
+		WithBlockTime(time.Nanosecond),
+		WithRecencyThreshold(time.Nanosecond),
+	)
+	require.NoError(t, err)
+	require.NoError(t, syncer.Start(ctx))
+
+	syncer.wantSync()
+	waitForSignal(t, ctx, getter.entered, "sync loop did not request headers")
+
+	stopReturned := make(chan error, 1)
+	go func() { stopReturned <- syncer.Stop(ctx) }()
+
+	waitForSignal(t, ctx, getter.canceled, "Stop did not cancel the active sync request")
+	select {
+	case err := <-stopReturned:
+		t.Fatalf("Stop returned before the sync loop exited: %v", err)
+	default:
+	}
+
+	close(getter.release)
+	require.NoError(t, waitForResult(t, ctx, stopReturned, "Stop did not return after the sync loop exited"))
+}
+
+func TestSyncer_LifecycleOrder(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	syncer := newLifecycleTestSyncer(t, ctx)
+
+	// Stop is idempotent before the first Start and after a completed Stop.
+	require.NoError(t, syncer.Stop(ctx))
+	require.NoError(t, syncer.Start(ctx))
+	require.ErrorIs(t, syncer.Start(ctx), ErrSyncerRunning)
+	require.NoError(t, syncer.Stop(ctx))
+	require.NoError(t, syncer.Stop(ctx))
+
+	// Every restart creates and completes a distinct run.
+	require.NoError(t, syncer.Start(ctx))
+	require.NoError(t, syncer.Stop(ctx))
+}
+
+func TestSyncer_ConcurrentStarts(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	syncer := newLifecycleTestSyncer(t, ctx)
+	const callers = 16
+	results := make(chan error, callers)
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			results <- syncer.Start(ctx)
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var started int
+	for err := range results {
+		switch {
+		case err == nil:
+			started++
+		case errors.Is(err, ErrSyncerStarting), errors.Is(err, ErrSyncerRunning):
+		default:
+			t.Fatalf("unexpected Start result: %v", err)
+		}
+	}
+	require.Equal(t, 1, started)
+	require.NoError(t, syncer.Stop(ctx))
+}
+
+func TestSyncer_ConcurrentStops(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	syncer := newLifecycleTestSyncer(t, ctx)
+	require.NoError(t, syncer.Start(ctx))
+
+	const callers = 16
+	results := make(chan error, callers)
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			results <- syncer.Stop(ctx)
+		}()
+	}
+	wg.Wait()
+	close(results)
+	for err := range results {
+		require.NoError(t, err)
+	}
+}
+
+func TestSyncer_StopDuringStart(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+	subscriber := &blockingSubscriber[*headertest.DummyHeader]{
+		Subscriber: headertest.NewDummySubscriber(),
+		entered:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	t.Cleanup(func() { closeOnce(subscriber.release) })
+	syncer, err := NewSyncer(
+		local.NewExchange(headertest.NewStore(t, suite, 10)),
+		newTestStore(t, ctx, head),
+		subscriber,
+		WithBlockTime(time.Hour),
+	)
+	require.NoError(t, err)
+
+	startReturned := make(chan error, 1)
+	go func() { startReturned <- syncer.Start(ctx) }()
+	waitForSignal(t, ctx, subscriber.entered, "Start did not begin verifier installation")
+	require.ErrorIs(t, syncer.Start(ctx), ErrSyncerStarting)
+
+	stopReturned := make(chan error, 1)
+	go func() { stopReturned <- syncer.Stop(ctx) }()
+	require.Eventually(t, func() bool {
+		syncer.lifecycleMu.Lock()
+		defer syncer.lifecycleMu.Unlock()
+		return syncer.lifecycleState == stateStopping
+	}, time.Second, time.Millisecond)
+	require.ErrorIs(t, syncer.Start(ctx), ErrSyncerStopping)
+
+	close(subscriber.release)
+	require.ErrorIs(t, waitForResult(t, ctx, startReturned, "Start did not return"), context.Canceled)
+	require.NoError(t, waitForResult(t, ctx, stopReturned, "Stop did not return"))
+}
+
+func TestSyncer_StartContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+	subscriber := &blockingSubscriber[*headertest.DummyHeader]{
+		Subscriber: headertest.NewDummySubscriber(),
+		entered:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	t.Cleanup(func() { closeOnce(subscriber.release) })
+	syncer, err := NewSyncer(
+		local.NewExchange(headertest.NewStore(t, suite, 10)),
+		newTestStore(t, ctx, head),
+		subscriber,
+		WithBlockTime(time.Hour),
+	)
+	require.NoError(t, err)
+
+	startCtx, startCancel := context.WithCancel(ctx)
+	startReturned := make(chan error, 1)
+	go func() { startReturned <- syncer.Start(startCtx) }()
+	waitForSignal(t, ctx, subscriber.entered, "Start did not begin verifier installation")
+
+	startCancel()
+	close(subscriber.release)
+	require.ErrorIs(t, waitForResult(t, ctx, startReturned, "canceled Start did not return"), context.Canceled)
+
+	syncer.lifecycleMu.Lock()
+	require.Equal(t, stateStopped, syncer.lifecycleState)
+	require.Nil(t, syncer.run)
+	syncer.lifecycleMu.Unlock()
+
+	require.NoError(t, syncer.Start(ctx))
+	require.NoError(t, syncer.Stop(ctx))
+}
+
+func TestSyncer_MetricsRestart(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+	syncer, err := NewSyncer(
+		local.NewExchange(headertest.NewStore(t, suite, 10)),
+		newTestStore(t, ctx, head),
+		headertest.NewDummySubscriber(),
+		WithBlockTime(time.Hour),
+		WithMetrics(),
+	)
+	require.NoError(t, err)
+
+	for range 2 {
+		require.NoError(t, syncer.Start(ctx))
+		require.NoError(t, syncer.Stop(ctx))
+	}
+}
+
+func TestSyncer_StopTimeoutCanBeRetried(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+	getter := &blockingGetter[*headertest.DummyHeader]{
+		Getter:   local.NewExchange(headertest.NewStore(t, suite, 100)),
+		entered:  make(chan struct{}),
+		canceled: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	t.Cleanup(func() { closeOnce(getter.release) })
+	syncer, err := NewSyncer(
+		getter,
+		newTestStore(t, ctx, head),
+		headertest.NewDummySubscriber(),
+		WithBlockTime(time.Nanosecond),
+		WithRecencyThreshold(time.Nanosecond),
+	)
+	require.NoError(t, err)
+	require.NoError(t, syncer.Start(ctx))
+	syncer.wantSync()
+	waitForSignal(t, ctx, getter.entered, "sync loop did not request headers")
+
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	stopCancel()
+	require.ErrorIs(t, syncer.Stop(stopCtx), context.Canceled)
+	waitForSignal(t, ctx, getter.canceled, "Stop did not cancel the active sync request")
+	require.ErrorIs(t, syncer.Start(ctx), ErrSyncerStopping)
+
+	close(getter.release)
+	require.NoError(t, syncer.Stop(ctx))
+	require.NoError(t, syncer.Start(ctx))
+	require.NoError(t, syncer.Stop(ctx))
+}
+
+func TestSyncer_StartWhileStopping(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+	getter := &blockingGetter[*headertest.DummyHeader]{
+		Getter:   local.NewExchange(headertest.NewStore(t, suite, 100)),
+		entered:  make(chan struct{}),
+		canceled: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	t.Cleanup(func() { closeOnce(getter.release) })
+	syncer, err := NewSyncer(
+		getter,
+		newTestStore(t, ctx, head),
+		headertest.NewDummySubscriber(),
+		WithBlockTime(time.Nanosecond),
+		WithRecencyThreshold(time.Nanosecond),
+	)
+	require.NoError(t, err)
+	require.NoError(t, syncer.Start(ctx))
+	syncer.wantSync()
+	waitForSignal(t, ctx, getter.entered, "sync loop did not request headers")
+
+	stopReturned := make(chan error, 1)
+	go func() { stopReturned <- syncer.Stop(ctx) }()
+	waitForSignal(t, ctx, getter.canceled, "Stop did not cancel the active sync request")
+	require.ErrorIs(t, syncer.Start(ctx), ErrSyncerStopping)
+
+	close(getter.release)
+	require.NoError(t, waitForResult(t, ctx, stopReturned, "Stop did not finish"))
+	require.NoError(t, syncer.Start(ctx))
+	require.NoError(t, syncer.Stop(ctx))
+}
+
+func newLifecycleTestSyncer(
+	t *testing.T,
+	ctx context.Context,
+) *Syncer[*headertest.DummyHeader] {
+	t.Helper()
+	suite := headertest.NewTestSuite(t)
+	head := suite.Head()
+	remoteStore := headertest.NewStore(t, suite, 10)
+	syncer, err := NewSyncer(
+		local.NewExchange(remoteStore),
+		newTestStore(t, ctx, head),
+		headertest.NewDummySubscriber(),
+		WithBlockTime(time.Hour),
+	)
+	require.NoError(t, err)
+	return syncer
+}
+
+type blockingGetter[H header.Header[H]] struct {
+	header.Getter[H]
+	entered  chan struct{}
+	canceled chan struct{}
+	release  chan struct{}
+}
+
+type blockingSubscriber[H header.Header[H]] struct {
+	header.Subscriber[H]
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingSubscriber[H]) SetVerifier(verifier func(context.Context, H) error) error {
+	close(s.entered)
+	<-s.release
+	return s.Subscriber.SetVerifier(verifier)
+}
+
+func (g *blockingGetter[H]) GetRangeByHeight(
+	ctx context.Context,
+	from H,
+	to uint64,
+) ([]H, error) {
+	close(g.entered)
+	<-ctx.Done()
+	close(g.canceled)
+	<-g.release
+	return nil, ctx.Err()
+}
+
+func waitForSignal(t *testing.T, ctx context.Context, signal <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-ctx.Done():
+		t.Fatal(message)
+	}
+}
+
+func waitForResult(t *testing.T, ctx context.Context, result <-chan error, message string) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-ctx.Done():
+		t.Fatal(message)
+		return nil
+	}
+}
+
+func closeOnce(ch chan struct{}) {
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
+}

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -3,7 +3,6 @@ package sync
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -41,6 +40,13 @@ type Syncer[H header.Header[H]] struct {
 	stateLk sync.RWMutex
 	state   State
 
+	// lifecycleMu protects lifecycleState and run.
+	lifecycleMu       sync.Mutex
+	lifecycleState    lifecycleState
+	run               *syncRun
+	verifierMu        sync.Mutex
+	verifierInstalled bool
+
 	// signals to start syncing
 	triggerSync chan struct{}
 	// pending keeps ranges of valid new network headers awaiting to be appended to store
@@ -49,10 +55,6 @@ type Syncer[H header.Header[H]] struct {
 	incomingMu sync.Mutex
 	// tailMu prevents concurrent tail movements
 	tailMu sync.Mutex
-
-	// controls lifecycle for syncLoop
-	ctx    context.Context
-	cancel context.CancelFunc
 
 	Params *Parameters
 
@@ -94,66 +96,6 @@ func NewSyncer[H header.Header[H]](
 		Params:      &params,
 		started:     make(chan struct{}),
 	}, nil
-}
-
-// Start starts the syncing routine.
-func (s *Syncer[H]) Start(ctx context.Context) error {
-	//nolint:gosec // G118 - cancel is called in Stop
-	s.ctx, s.cancel = context.WithCancel(context.Background())
-
-	// register validator for header subscriptions
-	// syncer does not subscribe itself and syncs headers together with validation
-	err := s.sub.SetVerifier(func(ctx context.Context, h H) error {
-		// HACK(@Wondertan):
-		//  During subjective init we request the Head and then the Tail.
-		//  However, we store them in the opposite order, s.t before Tail arrives
-		//  there is a window where Head awaits Tail without being stored.
-		//  During this window, headersub may deliver new network head. As it can't
-		//  see the awaiting Head, it triggers duplicate subjective initialization
-		//  which may frontrun Tail, violating the storing order and corrupting the store.
-		//  This hack basically stalls headersub until Syncer has fully started, but it should
-		//  not be this way.
-		//
-		//  This will be fixed with bsync as Syncer will learn how to verify Tail from Head backwards,
-		//  allowing Head to be stored first and then the Tail.
-		select {
-		case <-s.started:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-
-		if err := s.incomingNetworkHead(ctx, h); err != nil {
-			return err
-		}
-		// lazily trigger pruning by getting subjective tail
-		if _, err := s.subjectiveTail(ctx, h); err != nil {
-			log.Errorw("subjective tail", "head", h.Height(), "err", err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	// gets the latest head and kicks off syncing if necessary
-	_, err = s.Head(ctx)
-	if err != nil {
-		return fmt.Errorf("error getting latest head during Start: %w", err)
-	}
-	// start syncLoop only if Start is errorless
-	go s.syncLoop()
-	select {
-	case <-s.started:
-	default:
-		close(s.started)
-	}
-	return nil
-}
-
-// Stop stops Syncer.
-func (s *Syncer[H]) Stop(context.Context) error {
-	s.cancel()
-	return s.metrics.Close()
 }
 
 // SyncWait blocks until ongoing sync is done.
@@ -200,7 +142,7 @@ func (s *Syncer[H]) State() State {
 	state := s.state
 	s.stateLk.RUnlock()
 
-	head, err := s.store.Head(s.ctx)
+	head, err := s.store.Head(context.Background())
 	if err == nil {
 		state.Height = head.Height()
 	} else if state.Error == "" {
@@ -220,12 +162,12 @@ func (s *Syncer[H]) wantSync() {
 }
 
 // syncLoop controls syncing process.
-func (s *Syncer[H]) syncLoop() {
+func (s *Syncer[H]) syncLoop(runCtx context.Context) {
 	for {
 		select {
 		case <-s.triggerSync:
-			s.sync(s.ctx)
-		case <-s.ctx.Done():
+			s.sync(runCtx)
+		case <-runCtx.Done():
 			return
 		}
 	}

--- a/sync/syncer_head.go
+++ b/sync/syncer_head.go
@@ -205,7 +205,7 @@ func (s *Syncer[H]) setLocalHead(ctx context.Context, netHead H) {
 			"hash", netHead.Hash().String(),
 			"err", err)
 	}
-	s.metrics.newSubjectiveHead(s.ctx, netHead.Height())
+	s.metrics.newSubjectiveHead(ctx, netHead.Height())
 
 	storeHead, err := s.store.Head(ctx)
 	if err == nil && storeHead.Height() >= netHead.Height() {


### PR DESCRIPTION
## Summary

  Make `Syncer` lifecycle safe under concurrent Start/Stop and restart.

  - serialize lifecycle transitions with an explicit state machine
  - bind context, cancellation, and completion to each run
  - make `Stop` wait for the sync loop to exit
  - support metrics registration across restarts
  - add race-tested lifecycle coverage

  ## Behavior change

  `Stop(ctx)` now waits for in-flight sync work to exit, or returns `ctx.Err()`.
  Concurrent/repeated `Start` calls return lifecycle errors instead of racing.

  ## Testing

  - `go test -race ./sync`
  - `go vet ./sync`
  - `go test ./...`
