### PR TITLE
fix(p2p/server): fix partialRange response

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -259,7 +259,7 @@ func (serv *ExchangeServer[H]) handleRangeRequest(
 			"newMaxHeight", head.Height()+1,
 		)
 		// change `to` height to return a partial range
-		to = head.Height() + 1
+		to = min(to, head.Height()+1)
 	}
 
 	headersByRange, err := serv.store.GetRange(ctx, from, to)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -253,13 +253,13 @@ func (serv *ExchangeServer[H]) handleRangeRequest(
 			serv.metrics.rangeServed(ctx, time.Since(startTime), to-from, true)
 			return nil, header.ErrNotFound
 		}
+		// change `to` height to return a partial range
+		to = min(to, head.Height()+1)
 
 		log.Debugw("server: serving partial range",
 			"prevMaxHeight", to,
 			"newMaxHeight", head.Height()+1,
 		)
-		// change `to` height to return a partial range
-		to = min(to, head.Height()+1)
 	}
 
 	headersByRange, err := serv.store.GetRange(ctx, from, to)

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -129,6 +129,51 @@ func TestExchangeServer_Timeout(t *testing.T) {
 	}
 }
 
+// TestExchangeServer_partialRangeNotExpanded ensures that a request for a range
+// below the tail of a non-archival node does not expand `to` up to the head.
+// Regression test: requesting [1;2) against a node with a very high head used to
+// overwrite `to` with head.Height()+1, forcing GetRange over a huge range (OOM).
+func TestExchangeServer_partialRangeNotExpanded(t *testing.T) {
+	peer := createMocknet(t, 1)
+
+	head := headertest.RandDummyHeader(t)
+	head.HeightI = 10_000_000 // simulate a node synced far ahead
+	store := &partialRangeStore[*headertest.DummyHeader]{head: head}
+
+	server, err := NewExchangeServer[*headertest.DummyHeader](
+		peer[0],
+		store,
+		WithNetworkID[ServerParameters](networkID),
+	)
+	require.NoError(t, err)
+
+	// request a low range that is not stored (pruned/below tail)
+	_, err = server.handleRangeRequest(context.Background(), 1, 2)
+	require.NoError(t, err)
+
+	// `to` must stay at the requested value, not be expanded to head.Height()+1
+	require.Equal(t, uint64(2), store.gotTo)
+}
+
+// partialRangeStore is a minimal store where every height is reported as absent
+// (HasAt == false) and the head is far ahead. It records the `to` passed to GetRange.
+type partialRangeStore[H header.Header[H]] struct {
+	header.Store[H]
+	head  H
+	gotTo uint64
+}
+
+func (s *partialRangeStore[H]) HasAt(context.Context, uint64) bool { return false }
+
+func (s *partialRangeStore[H]) Head(context.Context, ...header.HeadOption[H]) (H, error) {
+	return s.head, nil
+}
+
+func (s *partialRangeStore[H]) GetRange(_ context.Context, _, to uint64) ([]H, error) {
+	s.gotTo = to
+	return nil, nil
+}
+
 var _ header.Store[*headertest.DummyHeader] = timeoutStore[*headertest.DummyHeader]{}
 
 // timeoutStore does nothing but waits till context cancellation for every method.


### PR DESCRIPTION
Resolves [PROTOCO-2383](https://linear.app/celestia/issue/PROTOCO-2383/fix-celestia-268)

Fix incorrect handling of `to` in `GetRangeRequest`