### PR TITLE
fix(p2p): stop peer tracker gc ticker

### DIFF
--- a/p2p/peer_tracker.go
+++ b/p2p/peer_tracker.go
@@ -226,6 +226,8 @@ func (p *peerTracker) peers() []*peerStat {
 // * connected peers whose scores are less than or equal than defaultScore;
 func (p *peerTracker) gc() {
 	ticker := time.NewTicker(gcCycle)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-p.ctx.Done():


### PR DESCRIPTION
Closes #223

## Summary

- stop the peer tracker garbage-collection ticker when gc exits
- release ticker resources when the tracker context is canceled

## Testing

- go test ./...
- go build ./...
- go vet ./...
- golangci-lint run --timeout 10m
- go mod tidy -diff
- git diff --check

