### PR TITLE
test(store): wait for append before checking head

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -39,6 +39,7 @@ func TestStore(t *testing.T) {
 	in := suite.GenDummyHeaders(10)
 	err = store.Append(ctx, in...)
 	require.NoError(t, err)
+	require.NoError(t, store.Sync(ctx))
 
 	out, err := store.GetRange(ctx, 2, 12)
 	require.NoError(t, err)


### PR DESCRIPTION
## Overview

Stabilizes `TestStore` by waiting for the asynchronous append pipeline before asserting the contiguous head. `Store.Append` intentionally returns after enqueueing writes (see #244), and `GetRange` can observe pending headers before `advanceHead` updates `contiguousHead`; the previous test therefore compared the new range with the old head intermittently.

The production behavior is unchanged.

## Validation

- Reproduced the original test failure 3 times in 200 runs
- Updated test: 500/500 focused runs pass
- `go test ./store`
- `go test -race ./store`
- `go vet ./...`
- `golangci-lint run` (0 issues)
- `git diff --check`

The repository-wide suite is currently blocked on an unrelated deterministic panic introduced on `main` by merged #406 (`TestExchangeServer_partialRangeNotExpanded` calls the newly required `Tail` method through a nil embedded store). It reproduces on both Go 1.26/darwin and Go 1.27/linux; details are posted on #406. This PR changes only `store/store_test.go`.