### PR TITLE
test(p2p): provide tail in partial range store

### DIFF
--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -185,7 +185,9 @@ func TestExchangeServer_partialRangeNotExpanded(t *testing.T) {
 
 	head := headertest.RandDummyHeader(t)
 	head.HeightI = 10_000_000 // simulate a node synced far ahead
-	store := &partialRangeStore[*headertest.DummyHeader]{head: head}
+	tail := headertest.RandDummyHeader(t)
+	tail.HeightI = 1
+	store := &partialRangeStore[*headertest.DummyHeader]{head: head, tail: tail}
 
 	server, err := NewExchangeServer[*headertest.DummyHeader](
 		peer[0],
@@ -207,6 +209,7 @@ func TestExchangeServer_partialRangeNotExpanded(t *testing.T) {
 type partialRangeStore[H header.Header[H]] struct {
 	header.Store[H]
 	head  H
+	tail  H
 	gotTo uint64
 }
 
@@ -214,6 +217,10 @@ func (s *partialRangeStore[H]) HasAt(context.Context, uint64) bool { return fals
 
 func (s *partialRangeStore[H]) Head(context.Context, ...header.HeadOption[H]) (H, error) {
 	return s.head, nil
+}
+
+func (s *partialRangeStore[H]) Tail(context.Context) (H, error) {
+	return s.tail, nil
 }
 
 func (s *partialRangeStore[H]) GetRange(_ context.Context, _, to uint64) ([]H, error) {


### PR DESCRIPTION
Follow-up to #406.

`handleRangeRequest` now queries `Tail` before checking the requested range. The focused `partialRangeStore` test double embedded a nil `header.Store`, so its inherited `Tail` method panicked and made the current `main` test suite fail deterministically.

Give the test double an explicit tail at the requested lower bound and implement `Tail`, preserving the original test path: the range is not below tail, `HasAt` remains false, and the assertion still verifies that `to` is not expanded to the distant head.

### Validation

- `go test ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test ./p2p -run ^'TestExchangeServer_partialRangeNotExpanded$' -count=100`\n- `go test -race ./p2p -run ^'TestExchangeServer_partialRangeNotExpanded$' -count=20`\n- `docker run --rm -v "$PWD:/workspace" -w /workspace golang:1.27 go test ./...`