### PR TITLE
ci: use Go version from go.mod

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: go.mod
 
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
Use the Go version declared by the module instead of the moving stable release. This prevents golangci-lint binaries built with an older Go version from loading packages from a newer standard library.

Validation: git diff --check